### PR TITLE
Block form when loading pair count

### DIFF
--- a/src/components/BaseComponent.js
+++ b/src/components/BaseComponent.js
@@ -138,7 +138,8 @@ export default function BaseComponent(ComposedComponent) {
 		addSubmitHook(hook) {
 			const id = this.getUUID(this.props.formData) || this.props.formContext._parentLajiFormId || "root";
 			const lajiFormInstance = new Context(this.props.formContext.contextId).formInstance;
-			const relativePointer = getRelativePointer(lajiFormInstance.tmpIdTree, lajiFormInstance.state.formData, this.props.idSchema.$id, id);
+			const idSchemaId = this.props.idSchema ? this.props.idSchema.$id : this.props.id;
+			const relativePointer = getRelativePointer(lajiFormInstance.tmpIdTree, lajiFormInstance.state.formData, idSchemaId, id);
 			return new Context(this.props.formContext.contextId).addSubmitHook(id, relativePointer, hook);
 		}
 	};

--- a/src/components/fields/UnitCountShorthandField.js
+++ b/src/components/fields/UnitCountShorthandField.js
@@ -10,6 +10,7 @@ import BaseComponent from "../BaseComponent";
 import {FetcherInput} from "../components";
 import { FormGroup, HelpBlock } from "react-bootstrap";
 import * as merge from "deepmerge";
+import Context from "../../Context";
 
 @VirtualSchemaField
 export default class UnitCountShorthandField extends React.Component {
@@ -56,9 +57,6 @@ export default class UnitCountShorthandField extends React.Component {
 		let formData = this.props.formData;
 		const {shorthandField, pairCountField} = getUiOptions(this.props.uiSchema);
 
-		let timestamp = Date.now();
-		this.promiseTimestamp = timestamp;
-
 		return new Promise((resolve) => {
 			if (!value || !taxonId) {
 				formData = updateSafelyWithJSONPointer(formData, undefined, pairCountField);
@@ -67,20 +65,18 @@ export default class UnitCountShorthandField extends React.Component {
 				return;
 			}
 
+			const context = new Context(this.props.formContext.contextId);
+			context.pushBlockingLoader();
 			apiClient.fetchCached("/autocomplete/pairCount", {q: value, taxonID: taxonId}).then(suggestion => {
-				if (timestamp !== this.promiseTimestamp) {
-					return;
-				}
 				formData = updateSafelyWithJSONPointer(formData, suggestion.key, shorthandField);
 				formData = updateSafelyWithJSONPointer(formData, suggestion.value, pairCountField);
 				this.props.onChange(formData);
+				new Context(this.props.formContext.contextId).popBlockingLoader();
 				resolve({success: suggestion.key ? true : undefined, value: suggestion.key});
 			}).catch(() => {
-				if (timestamp !== this.promiseTimestamp) {
-					return;
-				}
 				formData = updateSafelyWithJSONPointer(formData, undefined, pairCountField);
 				this.props.onChange(formData);
+				new Context(this.props.formContext.contextId).popBlockingLoader();
 				resolve({success: false, value: value});
 			});
 		});

--- a/src/components/fields/UnitCountShorthandField.js
+++ b/src/components/fields/UnitCountShorthandField.js
@@ -59,7 +59,7 @@ export default class UnitCountShorthandField extends React.Component {
 		let timestamp = Date.now();
 		this.promiseTimestamp = timestamp;
 
-		return new Promise((resolve) => {
+		return new Promise((resolve, reject) => {
 			if (!value || !taxonId) {
 				formData = updateSafelyWithJSONPointer(formData, undefined, pairCountField);
 				this.props.onChange(formData);
@@ -69,6 +69,7 @@ export default class UnitCountShorthandField extends React.Component {
 
 			apiClient.fetchCached("/autocomplete/pairCount", {q: value, taxonID: taxonId}).then(suggestion => {
 				if (timestamp !== this.promiseTimestamp) {
+					reject();
 					return;
 				}
 				formData = updateSafelyWithJSONPointer(formData, suggestion.key, shorthandField);
@@ -77,6 +78,7 @@ export default class UnitCountShorthandField extends React.Component {
 				resolve({success: suggestion.key ? true : undefined, value: suggestion.key});
 			}).catch(() => {
 				if (timestamp !== this.promiseTimestamp) {
+					reject();
 					return;
 				}
 				formData = updateSafelyWithJSONPointer(formData, undefined, pairCountField);
@@ -166,8 +168,10 @@ class CodeReader extends React.Component {
 
 		if (!(value === this.state.value && taxonID === this.state.taxonID)) {
 			this.setState({value, taxonID, loading: true, success: undefined});
-			parseCode(value, taxonID).then((result) => {
-				this.setState({loading: false, success: result.success, value: result.value});
+			this.addSubmitHook(() => {
+				return parseCode(value, taxonID).then((result) => {
+					this.setState({loading: false, success: result.success, value: result.value});
+				});
 			});
 		}
 	}


### PR DESCRIPTION
Fixes an issue with water bird form where user can save a form before pair count is loaded from api.