### PR TITLE
MultiTagArrayField

### DIFF
--- a/playground/styles.css
+++ b/playground/styles.css
@@ -1776,3 +1776,20 @@ min-height: 20px;
 .laji-form .input-group.multi-lang-input-group .input-group-text {
 	width: 40px;
 }
+
+.laji-form-multi-tag-array-field {
+	display: flex;
+}
+.laji-form-multi-tag-array-field-buttons {
+	flex: 0 0 auto;
+}
+.laji-form-multi-tag-array-field-buttons .btn-group-vertical {
+	margin-top: 20px;
+	margin-right: 5px;
+}
+.laji-form-multi-tag-array-field-content {
+	flex: 1 1 auto;
+}
+.laji-form-multi-tag-array-field.laji-form-multi-tag-array-field-active .rw-multiselect-tag:hover {
+	cursor: crosshair;
+}

--- a/playground/styles.css
+++ b/playground/styles.css
@@ -1777,19 +1777,22 @@ min-height: 20px;
 	width: 40px;
 }
 
-.laji-form-multi-tag-array-field {
-	display: flex;
-}
-.laji-form-multi-tag-array-field-buttons {
-	flex: 0 0 auto;
-}
 .laji-form-multi-tag-array-field-buttons .btn-group-vertical {
-	margin-top: 20px;
-	margin-right: 5px;
-}
-.laji-form-multi-tag-array-field-content {
-	flex: 1 1 auto;
+	margin-right: 17px;
 }
 .laji-form-multi-tag-array-field.laji-form-multi-tag-array-field-active .rw-multiselect-tag:hover {
 	cursor: crosshair;
+}
+.laji-form-multi-tag-array-field-buttons .btn-group-vertical button.active::before {
+	content: "";
+	position: absolute;
+	top: 50%;
+	margin-top: -14px;
+	border-top: 14px solid transparent;
+	border-bottom: 14px solid transparent;
+	border-left: 15px solid rgb(108, 117, 125);
+	right: -15px;
+}
+.laji-form-multi-tag-array-field-buttons .btn-group-vertical button.active.btn-outline-danger::before {
+	border-left: 1em solid rgb(220, 53, 69);
 }

--- a/src/components/LajiForm.tsx
+++ b/src/components/LajiForm.tsx
@@ -90,6 +90,7 @@ const fields = importLocalComponents<Field>("fields", [
 	"MultiLanguageField",
 	"SortArrayField",
 	"InputWithDefaultValueButtonField",
+	"MultiTagArrayField",
 	{"InputTransformerField": "ConditionalOnChangeField"}, // Alias for backward compatibility.
 	{"ConditionalField": "ConditionalUiSchemaField"}, // Alias for backward compatibility.
 	{"UnitRapidField": "UnitShorthandField"}, // Alias for backward compatibility.

--- a/src/components/components.js
+++ b/src/components/components.js
@@ -531,10 +531,6 @@ function ErrorPanelError({label, error, id, getId, extra = null, disabled, click
 	);
 }
 
-function NullTooltip() {
-	return <div />;
-}
-
 // Tooltip component that doesn't show tooltip for empty/undefined tooltip.
 export class TooltipComponent extends React.Component {
 	static contextType = ReactContext;
@@ -557,17 +553,19 @@ export class TooltipComponent extends React.Component {
 
 		const {OverlayTrigger, Tooltip} = this.context.theme;
 		const overlay = (
-			<OverlayTrigger
-				show={this.state.show}
-				placement={placement}
-				trigger={trigger === "hover" ? [] : trigger}
-				key={`${id}-overlay`}
-				overlay={
-					(tooltip) ? <Tooltip id={`${id}-tooltip`} className={`${className}`}>{React.isValidElement(tooltip) ? tooltip : <span dangerouslySetInnerHTML={{__html: tooltip}} />}</Tooltip> : <NullTooltip />
-				}
-			>
-				{children}
-			</OverlayTrigger>
+			tooltip ? (
+				<OverlayTrigger
+					show={this.state.show}
+					placement={placement}
+					trigger={trigger === "hover" ? [] : trigger}
+					key={`${id}-overlay`}
+					overlay={
+						<Tooltip id={`${id}-tooltip`} className={`${className}`}>{React.isValidElement(tooltip) ? tooltip : <span dangerouslySetInnerHTML={{__html: tooltip}} />}</Tooltip>
+					}
+				>
+					{children}
+				</OverlayTrigger>
+			): <React.Fragment>{children}</React.Fragment>
 		);
 
 		return (trigger === "hover") ? (

--- a/src/components/fields/MultiTagArrayField.js
+++ b/src/components/fields/MultiTagArrayField.js
@@ -3,7 +3,7 @@ import * as PropTypes from "prop-types";
 import BaseComponent from "../BaseComponent";
 import {classNames, getUiOptions} from "../../utils";
 import ReactContext from "../../ReactContext";
-import {Button} from "../components";
+import {Affix, Button} from "../components";
 
 
 @BaseComponent
@@ -47,8 +47,17 @@ export default class MultiTagArrayField extends React.Component {
 		this.state = {activeButtonIdx: undefined};
 	}
 
+	setContainerRef = (elem) => {
+		this.containerElem = elem;
+	}
+
+	getContainerRef = () => {
+		return this.containerElem;
+	}
+
 	render() {
 		const SchemaField = this.props.registry.fields.SchemaField;
+		const {Row, Col} = this.context.theme;
 		const {schema, uiSchema, idSchema, errorSchema, formData = {}} = this.props;
 		const uiOptions = getUiOptions(uiSchema);
 		const {buttons = []} = uiOptions;
@@ -58,20 +67,24 @@ export default class MultiTagArrayField extends React.Component {
 		const propertyKeys = Object.keys(schema.properties)
 
 		return (
-			<div className={`laji-form-multi-tag-array-field${activeButtonIdx !== undefined ? " laji-form-multi-tag-array-field-active" : ""}`}>
-				<div className={"laji-form-multi-tag-array-field-buttons"}>
-					<div className={"btn-group-vertical"}>
-						{ buttons.map((btnProps, idx) => (
-							<Button
-								key={idx}
-								onClick={this.onButtonClick(idx, btnProps)}
-								variant={btnProps.operation === "delete" ? "danger": "default"}
-								className={classNames(btnProps.className, activeButtonIdx === idx ? "active" : "")}
-							>{ btnProps.label }</Button>
-						)) }
-					</div>
-				</div>
-				<div className={"laji-form-multi-tag-array-field-content"}>
+			<Row className={`laji-form-multi-tag-array-field${activeButtonIdx !== undefined ? " laji-form-multi-tag-array-field-active" : ""}`}>
+				<Col xs={3} sm={3} md={2} lg={2} className={"laji-form-multi-tag-array-field-buttons"} ref={this.setContainerRef}>
+					<Affix getContainer={this.getContainerRef}
+						   topOffset={this.props.formContext.topOffset + 15}
+						   bottomOffset={this.props.formContext.bottomOffset}>
+						<div className={"btn-group-vertical"}>
+							{ buttons.map((btnProps, idx) => (
+								<Button
+									key={idx}
+									onClick={this.onButtonClick(idx, btnProps)}
+									variant={btnProps.operation === "delete" ? "outline-danger": "default"}
+									className={classNames(btnProps.className, activeButtonIdx === idx ? "active" : "")}
+								>{ btnProps.label }</Button>
+							)) }
+						</div>
+					</Affix>
+				</Col>
+				<Col xs={9} sm={9} md={10} lg={10} className={"laji-form-multi-tag-array-field-content"}>
 					{ propertyKeys.map(key => (
 						<SchemaField
 							{...this.props}
@@ -92,8 +105,8 @@ export default class MultiTagArrayField extends React.Component {
 							onChange={this.onChange(key)}
 						/>
 					)) }
-				</div>
-			</div>
+				</Col>
+			</Row>
 		);
 	}
 

--- a/src/components/fields/MultiTagArrayField.js
+++ b/src/components/fields/MultiTagArrayField.js
@@ -1,9 +1,9 @@
 import * as React from "react";
 import * as PropTypes from "prop-types";
 import BaseComponent from "../BaseComponent";
-import {classNames, getUiOptions} from "../../utils";
+import { classNames, getUiOptions } from "../../utils";
 import ReactContext from "../../ReactContext";
-import {Affix, Button} from "../components";
+import { Affix, Button } from "../components";
 
 
 @BaseComponent
@@ -64,14 +64,14 @@ export default class MultiTagArrayField extends React.Component {
 
 		const {activeButtonIdx} = this.state;
 
-		const propertyKeys = Object.keys(schema.properties)
+		const propertyKeys = Object.keys(schema.properties);
 
 		return (
-			<Row className={`laji-form-multi-tag-array-field${activeButtonIdx !== undefined ? " laji-form-multi-tag-array-field-active" : ""}`}>
+			<Row className={classNames("laji-form-multi-tag-array-field", activeButtonIdx && "laji-form-multi-tag-array-field-active")}>
 				<Col xs={3} sm={3} md={2} lg={2} className={"laji-form-multi-tag-array-field-buttons"} ref={this.setContainerRef}>
 					<Affix getContainer={this.getContainerRef}
-						   topOffset={this.props.formContext.topOffset + 15}
-						   bottomOffset={this.props.formContext.bottomOffset}>
+						topOffset={this.props.formContext.topOffset + 15}
+						bottomOffset={this.props.formContext.bottomOffset}>
 						<div className={"btn-group-vertical"}>
 							{ buttons.map((btnProps, idx) => (
 								<Button
@@ -151,7 +151,7 @@ export default class MultiTagArrayField extends React.Component {
 			fromFieldNewValue.splice(idx, 1);
 
 			if (operation === "move") {
-				const toFieldNewValue = [...(formData[toField] || []), value]
+				const toFieldNewValue = [...(formData[toField] || []), value];
 				formData = {...formData, [fromField]: fromFieldNewValue, [toField]: toFieldNewValue};
 			} else {
 				formData = {...formData, [fromField]: fromFieldNewValue};

--- a/src/components/fields/MultiTagArrayField.js
+++ b/src/components/fields/MultiTagArrayField.js
@@ -1,0 +1,150 @@
+import * as React from "react";
+import * as PropTypes from "prop-types";
+import BaseComponent from "../BaseComponent";
+import {classNames, getUiOptions} from "../../utils";
+import ReactContext from "../../ReactContext";
+import {Button} from "../components";
+
+
+@BaseComponent
+export default class MultiTagArrayField extends React.Component {
+	static contextType = ReactContext;
+	static propTypes = {
+		uiSchema: PropTypes.shape({
+			"ui:options": PropTypes.shape({
+				buttons: PropTypes.arrayOf(PropTypes.oneOfType(
+					[
+						PropTypes.shape({
+							operation: PropTypes.oneOf(["moveAll"]),
+							fromField: PropTypes.string.isRequired,
+							toField: PropTypes.string.isRequired,
+							label: PropTypes.string,
+							className: PropTypes.string
+						}),
+						PropTypes.shape({
+							operation: PropTypes.oneOf(["move"]),
+							toField: PropTypes.string.isRequired,
+							label: PropTypes.string,
+							className: PropTypes.string
+						}),
+						PropTypes.shape({
+							operation: PropTypes.oneOf(["delete"]),
+							label: PropTypes.string,
+							className: PropTypes.string
+						})
+					]
+				))
+			})
+		}),
+		schema: PropTypes.shape({
+			type: PropTypes.oneOf(["object"])
+		}).isRequired,
+		formData: PropTypes.object
+	}
+
+	constructor(props) {
+		super(props);
+		this.state = {activeButtonIdx: undefined};
+	}
+
+	render() {
+		const SchemaField = this.props.registry.fields.SchemaField;
+		const {schema, uiSchema, idSchema, errorSchema, formData = {}} = this.props;
+		const uiOptions = getUiOptions(uiSchema);
+		const {buttons = []} = uiOptions;
+
+		const {activeButtonIdx} = this.state;
+
+		const propertyKeys = Object.keys(schema.properties)
+
+		return (
+			<div className={`laji-form-multi-tag-array-field${activeButtonIdx !== undefined ? " laji-form-multi-tag-array-field-active" : ""}`}>
+				<div className={"laji-form-multi-tag-array-field-buttons"}>
+					<div className={"btn-group-vertical"}>
+						{ buttons.map((btnProps, idx) => (
+							<Button
+								key={idx}
+								onClick={this.onButtonClick(idx, btnProps)}
+								variant={btnProps.operation === "delete" ? "danger": "default"}
+								className={classNames(btnProps.className, activeButtonIdx === idx ? "active" : "")}
+							>{ btnProps.label }</Button>
+						)) }
+					</div>
+				</div>
+				<div className={"laji-form-multi-tag-array-field-content"}>
+					{ propertyKeys.map(key => (
+						<SchemaField
+							{...this.props}
+							key={key}
+							schema={{title: "", ...schema.properties[key]}}
+							uiSchema={{
+								"ui:field": "TagArrayField",
+								"ui:options": {
+									...uiOptions,
+									buttons: undefined,
+									onTagClick: this.onTagClick(key)
+								}
+							}}
+							errorSchema={errorSchema[key] || {}}
+							idSchema={idSchema[key]}
+							formData={formData[key] || []}
+							required={uiSchema[key]?.["ui:required"] || false}
+							onChange={this.onChange(key)}
+						/>
+					)) }
+				</div>
+			</div>
+		);
+	}
+
+	onChange = (key) => (formData) => {
+		const newFormData = {...this.props.formData, [key]: formData};
+		this.props.onChange(newFormData);
+	}
+
+	onButtonClick = (idx, {operation, fromField, toField}) => () => {
+		const {activeButtonIdx} = this.state;
+		if (activeButtonIdx === idx) {
+			this.setState({activeButtonIdx: undefined});
+			return;
+		}
+
+		if (operation === "moveAll") {
+			const toFieldNewValue = (this.props.formData[toField] || []).concat(this.props.formData[fromField] || []);
+			const newFormData = {...this.props.formData, [fromField]: [], [toField]: toFieldNewValue};
+			this.props.onChange(newFormData);
+		} else if (operation === "move" || operation === "delete") {
+			this.setState({activeButtonIdx: idx});
+		}
+	}
+
+	onTagClick = (fromField) => (idx) => {
+		const {activeButtonIdx} = this.state;
+		if (activeButtonIdx === undefined) {
+			return;
+		}
+
+		const {buttons = []} = getUiOptions(this.props.uiSchema);
+		const {operation, toField} = buttons[activeButtonIdx];
+		if (fromField === toField) {
+			return;
+		}
+
+		let formData = this.props.formData;
+
+		if (operation === "move" || operation === "delete") {
+			const value = formData[fromField][idx];
+			const fromFieldNewValue = [...formData[fromField]];
+			fromFieldNewValue.splice(idx, 1);
+
+			if (operation === "move") {
+				const toFieldNewValue = [...(formData[toField] || []), value]
+				formData = {...formData, [fromField]: fromFieldNewValue, [toField]: toFieldNewValue};
+			} else {
+				formData = {...formData, [fromField]: fromFieldNewValue};
+			}
+
+			this.props.onChange(formData);
+		}
+	}
+}

--- a/src/components/fields/MultiTagArrayField.tsx
+++ b/src/components/fields/MultiTagArrayField.tsx
@@ -5,10 +5,11 @@ import { classNames, getUiOptions } from "../../utils";
 import ReactContext from "../../ReactContext";
 import { Affix, Button } from "../components";
 import { FieldProps } from "../LajiForm";
-import { RefObject } from "react";
+import { ReactInstance } from "react";
 import update from "immutability-helper";
 import { IdSchema } from "@rjsf/utils";
 import * as memoize from "memoizee";
+import { findDOMNode } from "react-dom";
 
 interface CommonButtonOptions {
 	label?: string;
@@ -74,13 +75,13 @@ export default class MultiTagArrayField extends React.Component<FieldProps, Stat
 
 	state: State = {activeButtonIdx: undefined};
 
-	private affixContainerElem?: RefObject<HTMLElement>;
+	private affixContainerElem: Element|null = null;
 
-	setAffixContainerRef = (elem: RefObject<HTMLElement>) => {
-		this.affixContainerElem = elem;
+	setAffixContainer = (ref: ReactInstance) => {
+		this.affixContainerElem = findDOMNode(ref) as Element|null;
 	}
 
-	getAffixContainerRef = (): RefObject<HTMLElement>|undefined => {
+	getAffixContainer = (): Element|null => {
 		return this.affixContainerElem;
 	}
 
@@ -96,9 +97,9 @@ export default class MultiTagArrayField extends React.Component<FieldProps, Stat
 		const propertyKeys = Object.keys(schema.properties);
 
 		return (
-			<Row className={classNames("laji-form-multi-tag-array-field", activeButtonIdx && "laji-form-multi-tag-array-field-active")}>
-				<Col xs={3} sm={3} md={2} lg={2} className={"laji-form-multi-tag-array-field-buttons"} ref={this.setAffixContainerRef}>
-					<Affix getContainer={this.getAffixContainerRef}
+			<Row className={classNames("laji-form-multi-tag-array-field", activeButtonIdx && "laji-form-multi-tag-array-field-active")} ref={this.setAffixContainer}>
+				<Col xs={3} sm={3} md={2} lg={2} className={"laji-form-multi-tag-array-field-buttons"}>
+					<Affix getContainer={this.getAffixContainer}
 					       topOffset={this.props.formContext.topOffset + 15}
 					       bottomOffset={this.props.formContext.bottomOffset}>
 						<div className={"btn-group-vertical"}>

--- a/src/components/fields/TagArrayField.js
+++ b/src/components/fields/TagArrayField.js
@@ -51,7 +51,7 @@ export class TagInputComponent extends React.Component {
 	}
 
 	onKeyDown = (e) => {
-		const {value} = this.state;
+		const value = this.getTrimmedValue();
 		const {tags = []} = this.props;
 		const separatorKeys = this.getSeparatorKeys(this.props.uiSchema);
 		if (separatorKeys.includes(e.key) && !isEmptyString(value)) {
@@ -79,8 +79,9 @@ export class TagInputComponent extends React.Component {
 	onBlur = (e) => {
 		this.setState({focused: false});
 		triggerParentComponent("onBlur", e, this.props);
-		if (!isEmptyString(this.state.value)) {
-			this.props.onChange([...(this.props.tags || []), this.state.value], "blur");
+		const value = this.getTrimmedValue();
+		if (!isEmptyString(value)) {
+			this.props.onChange([...(this.props.tags || []), value], "blur");
 		}
 
 	}
@@ -96,13 +97,12 @@ export class TagInputComponent extends React.Component {
 	onInputChange = (e) => {
 		const {onInputChange} = this.props;
 		onInputChange && e.persist();
-		let {target: {value}} = e;
-		value = value.trim();
+		const {target: {value}} = e;
 
 		const separatorKeys = this.getSeparatorKeys(this.props.uiSchema);
 		const splitted = separatorKeys.reduce((splitted, separator) => 
 			splitted.reduce((_splitted, i) => ([..._splitted, ...i.split(separator)]), []),
-		[value]).filter(s => !isEmptyString(s));
+		[value]).map(s => s.trim()).filter(s => !isEmptyString(s));
 
 		this.setState({value}, () => {
 			onInputChange && this.props.onInputChange(e);
@@ -110,6 +110,11 @@ export class TagInputComponent extends React.Component {
 				this.props.onChange([...(this.props.tags || []), ...splitted]);
 			}
 		});
+	}
+
+	getTrimmedValue() {
+		const {value} = this.state;
+		return value.trim();
 	}
 
 	render() {

--- a/src/components/fields/TagArrayField.js
+++ b/src/components/fields/TagArrayField.js
@@ -114,7 +114,7 @@ export class TagInputComponent extends React.Component {
 
 	getTrimmedValue() {
 		const {value} = this.state;
-		return value.trim();
+		return value?.trim();
 	}
 
 	render() {

--- a/src/components/fields/TagArrayField.js
+++ b/src/components/fields/TagArrayField.js
@@ -9,7 +9,8 @@ export default class TagArrayField extends React.Component {
 	static propTypes = {
 		uiSchema: PropTypes.shape({
 			"ui:options": PropTypes.shape({
-				separatorKeys: PropTypes.arrayOf(PropTypes.string)
+				separatorKeys: PropTypes.arrayOf(PropTypes.string),
+				showDeleteButton: PropTypes.bool
 			})
 		}),
 		schema: PropTypes.shape({
@@ -111,7 +112,7 @@ export class TagInputComponent extends React.Component {
 	}
 
 	render() {
-		let {tags = [], InputComponent, readonly, disabled} = this.props;
+		let {tags = [], InputComponent, readonly, disabled, uiSchema} = this.props;
 		tags = tags.filter(s => !isEmptyString(s));
 		const {value = ""} = this.state;
 
@@ -128,15 +129,17 @@ export class TagInputComponent extends React.Component {
 			onKeyDown: this.onKeyDown
 		};
 
+		const {showDeleteButton = true, onTagClick} = getUiOptions(uiSchema);
+
 		return (
 			<div className={`rw-multiselect rw-widget${this.state.focused ? " rw-state-focus" : ""}${readonly || disabled ? " rw-state-disabled" : ""}`}
 				onClick={this.onClick}>
 				<div className="rw-widget-input rw-widget-picked rw-widget-container">
 					<ul className="rw-multiselect-taglist">
 						{tags.map((item, idx) => 
-							<li key={idx} className="rw-multiselect-tag">
+							<li key={idx} className="rw-multiselect-tag" onClick={() => onTagClick?.(idx)}>
 								{item}
-								<span className="rw-tag-btn" onClick={this.onRemove(idx)} tabIndex={0} onKeyDown={this.props.formContext.utils.keyboardClick(this.onRemove(idx))}>×</span>
+								{showDeleteButton ? <span className="rw-tag-btn" onClick={this.onRemove(idx)} tabIndex={0} onKeyDown={this.props.formContext.utils.keyboardClick(this.onRemove(idx))}>×</span> : ""}
 							</li>
 						)}
 					</ul>

--- a/src/components/fields/TagArrayField.js
+++ b/src/components/fields/TagArrayField.js
@@ -3,6 +3,7 @@ import { findDOMNode } from "react-dom";
 import * as PropTypes from "prop-types";
 import { isEmptyString, getUiOptions, triggerParentComponent } from "../../utils";
 import BaseComponent from "../BaseComponent";
+import * as memoize from "memoizee";
 
 @BaseComponent
 export default class TagArrayField extends React.Component {
@@ -64,11 +65,11 @@ export class TagInputComponent extends React.Component {
 		triggerParentComponent("onKeyDown", e, this.props);
 	}
 
-	onRemove = (idx) => () => {
+	onRemove = memoize((idx) => () => {
 		const tags = [...(this.props.tags || [])];
 		tags.splice(idx, 1);
 		this.props.onChange(tags, "remove");
-	}
+	})
 
 	onFocus = (e) => {
 		this.setState({focused: true}, () => {
@@ -112,6 +113,11 @@ export class TagInputComponent extends React.Component {
 		});
 	}
 
+	onTagClick = memoize((idx) => () => {
+		const {onTagClick} = getUiOptions(this.props.uiSchema);
+		onTagClick?.(idx);
+	});
+
 	getTrimmedValue() {
 		const {value} = this.state;
 		return value?.trim();
@@ -135,7 +141,7 @@ export class TagInputComponent extends React.Component {
 			onKeyDown: this.onKeyDown
 		};
 
-		const {showDeleteButton = true, onTagClick} = getUiOptions(uiSchema);
+		const {showDeleteButton = true} = getUiOptions(uiSchema);
 
 		return (
 			<div className={`rw-multiselect rw-widget${this.state.focused ? " rw-state-focus" : ""}${readonly || disabled ? " rw-state-disabled" : ""}`}
@@ -143,7 +149,7 @@ export class TagInputComponent extends React.Component {
 				<div className="rw-widget-input rw-widget-picked rw-widget-container">
 					<ul className="rw-multiselect-taglist">
 						{tags.map((item, idx) => 
-							<li key={idx} className="rw-multiselect-tag" onClick={() => onTagClick?.(idx)}>
+							<li key={idx} className="rw-multiselect-tag" onClick={this.onTagClick(idx)}>
 								{item}
 								{showDeleteButton ? <span className="rw-tag-btn" onClick={this.onRemove(idx)} tabIndex={0} onKeyDown={this.props.formContext.utils.keyboardClick(this.onRemove(idx))}>×</span> : ""}
 							</li>

--- a/src/components/fields/TagArrayField.js
+++ b/src/components/fields/TagArrayField.js
@@ -96,7 +96,8 @@ export class TagInputComponent extends React.Component {
 	onInputChange = (e) => {
 		const {onInputChange} = this.props;
 		onInputChange && e.persist();
-		const {target: {value}} = e;
+		let {target: {value}} = e;
+		value = value.trim();
 
 		const separatorKeys = this.getSeparatorKeys(this.props.uiSchema);
 		const splitted = separatorKeys.reduce((splitted, separator) => 

--- a/src/themes/bs3.tsx
+++ b/src/themes/bs3.tsx
@@ -41,8 +41,13 @@ import {
 	DropdownMenuProps,
 	DropdownToggleProps,
 	Breadcrumb as BreadcrumbI,
-	OverlayTriggerProps
+	OverlayTriggerProps,
+	ButtonVariant as ButtonVariantI
 } from "./theme";
+
+const mapBtnVariant = (variant?: ButtonVariantI): ButtonVariantI|undefined => {
+	return variant?.replace("outline-", "");
+};
 
 const Panel = React.forwardRef<_Panel, PanelProps>(({variant, ...props}, ref) => <_Panel {...props} bsStyle={variant} ref={ref}/>);
 const __Panel: PanelI = (Panel as unknown as PanelI);
@@ -93,7 +98,7 @@ const theme: Theme = {
 	Panel: __Panel,
 	Table,
 	ProgressBar,
-	Button: React.forwardRef<Button, ButtonProps>(({variant, small, ...props}, ref) => <Button {...props} bsStyle={variant} bsSize={small ? "small" : undefined} ref={ref}/>),
+	Button: React.forwardRef<Button, ButtonProps>(({variant, small, ...props}, ref) => <Button {...props} bsStyle={mapBtnVariant(variant)} bsSize={small ? "small" : undefined} ref={ref}/>),
 	ButtonGroup,
 	ButtonToolbar,
 	Overlay,

--- a/src/themes/theme.ts
+++ b/src/themes/theme.ts
@@ -1,6 +1,6 @@
 import * as React from "react";
 
-export type Variant = "default" | "primary" | "success" | "info" | "warning" | "danger" | string;
+export type Variant = "default" | "primary" | "success" | "info" | "warning" | "danger" | "outline-danger" | string;
 export type ButtonVariant = Variant | "link";
 
 export interface HasMaybeChildren {

--- a/test/transaction-form-spec.ts
+++ b/test/transaction-form-spec.ts
@@ -1,4 +1,5 @@
-import { Form, createForm, EnumWidgetPOI } from "./test-utils";
+import {Form, createForm, EnumWidgetPOI} from "./test-utils";
+import {$, by, protractor} from "protractor";
 
 describe("transaction form (MHL.930)", () => {
 	let form: Form;
@@ -29,5 +30,37 @@ describe("transaction form (MHL.930)", () => {
 		const formData = await form.getChangedData();
 		expect(formData.localPerson).toBe("Test, User");
 		expect(formData.localPersonEmail).toBe("user.test@email.com");
+	});
+
+	describe("specimen fields", () => {
+		it("adds the ids", async () => {
+			const $input = form.$getInputWidget("awayIDs")
+			await $input.sendKeys("abc cde efg");
+			await $input.sendKeys(protractor.Key.TAB);
+
+			let formData = await form.getChangedData();
+			expect(formData.awayIDs).toEqual(["abc", "cde", "efg"]);
+		});
+
+		it("marks all as returned", async () => {
+			const returnAllButton$ = $(".laji-form-multi-tag-array-field-buttons").all(by.tagName("button")).get(0);
+			await returnAllButton$.click();
+
+			const formData = await form.getChangedData();
+			expect(formData.awayIDs).toEqual([]);
+			expect(formData.returnedIDs).toEqual(["abc", "cde", "efg"]);
+		});
+
+		it("marks selected ids as missing", async () => {
+			const markAsMissingButton$ = $(".laji-form-multi-tag-array-field-buttons").all(by.tagName("button")).get(3);
+			await markAsMissingButton$.click();
+
+			const tags$ = form.$locate("returnedIDs").$$(".rw-multiselect-tag");
+			await tags$.get(1).click();
+
+			const formData = await form.getChangedData();
+			expect(formData.returnedIDs).toEqual(["abc", "efg"]);
+			expect(formData.missingIDs).toEqual(["cde"]);
+		});
 	});
 });

--- a/test/transaction-form-spec.ts
+++ b/test/transaction-form-spec.ts
@@ -1,5 +1,5 @@
-import {Form, createForm, EnumWidgetPOI} from "./test-utils";
-import {$, by, protractor} from "protractor";
+import { Form, createForm, EnumWidgetPOI } from "./test-utils";
+import { $, by, protractor } from "protractor";
 
 describe("transaction form (MHL.930)", () => {
 	let form: Form;


### PR DESCRIPTION
Can be tested locally at http://localhost:8083/?id=MHL.930&theme=bs5&lang=en by selecting a type and scrolling to "Specimens" section.

Adds a new field, `MultiTagArrayField`, that can be used to define multiple `TagArrayField`s and functionalities related to them (like allowing the user to move tags between different `TagArrayField`s).