### PR TITLE
PdfArrayField

### DIFF
--- a/playground/styles.css
+++ b/playground/styles.css
@@ -587,7 +587,8 @@ min-height: 20px;
 .laji-form .col-lg-1, .laji-form .col-lg-10, .laji-form .col-lg-11, .laji-form .col-lg-12, .laji-form .col-lg-2, .laji-form .col-lg-3, .laji-form .col-lg-4, .laji-form .col-lg-5, .laji-form .col-lg-6, .laji-form .col-lg-7, .laji-form .col-lg-8, .laji-form .col-lg-9,
 .laji-form .col-md-1, .laji-form .col-md-10, .laji-form .col-md-11, .laji-form .col-md-12, .laji-form .col-md-2, .laji-form .col-md-3, .laji-form .col-md-4, .laji-form .col-md-5, .laji-form .col-md-6, .laji-form .col-md-7, .laji-form .col-md-8, .laji-form .col-md-9,
 .laji-form .col-sm-1, .laji-form .col-sm-10, .laji-form .col-sm-11, .laji-form .col-sm-12, .laji-form .col-sm-2, .laji-form .col-sm-3, .laji-form .col-sm-4, .laji-form .col-sm-5, .laji-form .col-sm-6, .laji-form .col-sm-7, .laji-form .col-sm-8, .laji-form .col-sm-9,
-.laji-form .col-xs-1, .laji-form .col-xs-10, .laji-form .col-xs-11, .laji-form .col-xs-12, .laji-form .col-xs-2, .laji-form .col-xs-3, .laji-form .col-xs-4, .laji-form .col-xs-5, .laji-form .col-xs-6, .laji-form .col-xs-7, .laji-form .col-xs-8, .laji-form .col-xs-9 {
+.laji-form .col-xs-1, .laji-form .col-xs-10, .laji-form .col-xs-11, .laji-form .col-xs-12, .laji-form .col-xs-2, .laji-form .col-xs-3, .laji-form .col-xs-4, .laji-form .col-xs-5, .laji-form .col-xs-6, .laji-form .col-xs-7, .laji-form .col-xs-8, .laji-form .col-xs-9,
+.laji-form .col-1,    .laji-form .col-10,    .laji-form .col-11,    .laji-form .col-12,    .laji-form .col-2,    .laji-form .col-3,    .laji-form .col-4,    .laji-form .col-5,    .laji-form .col-6,    .laji-form .col-7,    .laji-form .col-8,    .laji-form .col-9 {
 	padding-right:3px;
 	padding-left:3px;
 }

--- a/src/components/LajiForm.tsx
+++ b/src/components/LajiForm.tsx
@@ -91,6 +91,7 @@ const fields = importLocalComponents<Field>("fields", [
 	"SortArrayField",
 	"InputWithDefaultValueButtonField",
 	"MultiTagArrayField",
+	"PdfArrayField",
 	{"InputTransformerField": "ConditionalOnChangeField"}, // Alias for backward compatibility.
 	{"ConditionalField": "ConditionalUiSchemaField"}, // Alias for backward compatibility.
 	{"UnitRapidField": "UnitShorthandField"}, // Alias for backward compatibility.

--- a/src/components/fields/ImageArrayField.tsx
+++ b/src/components/fields/ImageArrayField.tsx
@@ -68,7 +68,7 @@ export default class ImageArrayField extends React.Component<FieldProps, ImageAr
 	}
 }
 
-interface MediaArrayState {
+export interface MediaArrayState {
 	tmpMedias: number[];
 	addModal?: any;
 	dragging?: boolean
@@ -825,6 +825,7 @@ export function MediaArrayField<LFC extends Constructor<React.Component<FieldPro
 interface ThumbnailProps {
 	id?: string;
 	apiClient: ApiClient;
+	apiEndpoint?: string;
 	dataURL?: string;
 	loading?: boolean;
 }
@@ -832,7 +833,7 @@ interface ThumbnailState {
 	url?: string;
 }
 
-class Thumbnail extends React.PureComponent<ThumbnailProps, ThumbnailState> {
+export class Thumbnail extends React.PureComponent<ThumbnailProps, ThumbnailState> {
 	mounted: boolean;
 
 	constructor(props: ThumbnailProps) {
@@ -853,9 +854,9 @@ class Thumbnail extends React.PureComponent<ThumbnailProps, ThumbnailState> {
 		this.updateURL(props);
 	}
 
-	updateURL = ({id, apiClient}: ThumbnailProps) => {
+	updateURL = ({id, apiClient, apiEndpoint = 'images'}: ThumbnailProps) => {
 		if (!id) return;
-		apiClient.fetchCached(`/images/${id}`, undefined, {failSilently: true}).then((response: any) => {
+		apiClient.fetchCached(`/${apiEndpoint}/${id}`, undefined, {failSilently: true}).then((response: any) => {
 			if (!this.mounted) return;
 			this.setState({url: response.squareThumbnailURL});
 		});

--- a/src/components/fields/ImageArrayField.tsx
+++ b/src/components/fields/ImageArrayField.tsx
@@ -854,7 +854,7 @@ export class Thumbnail extends React.PureComponent<ThumbnailProps, ThumbnailStat
 		this.updateURL(props);
 	}
 
-	updateURL = ({id, apiClient, apiEndpoint = 'images'}: ThumbnailProps) => {
+	updateURL = ({id, apiClient, apiEndpoint = "images"}: ThumbnailProps) => {
 		if (!id) return;
 		apiClient.fetchCached(`/${apiEndpoint}/${id}`, undefined, {failSilently: true}).then((response: any) => {
 			if (!this.mounted) return;

--- a/src/components/fields/PdfArrayField.tsx
+++ b/src/components/fields/PdfArrayField.tsx
@@ -1,0 +1,30 @@
+import * as React from "react";
+import { FieldProps } from "../LajiForm";
+import { MediaArrayField, MediaArrayState, Thumbnail } from "./ImageArrayField";
+
+@MediaArrayField
+export default class PdfArrayField extends React.Component<FieldProps, MediaArrayState> {
+	ALLOWED_FILE_TYPES = ["application/pdf"];
+	ACCEPT_FILE_TYPES = ["application/pdf"];
+	MAX_FILE_SIZE = 20000000;
+	KEY = "PDF";
+	ENDPOINT = "pdf";
+	GLYPH = "paperclip";
+	TRANSLATION_TAKE_NEW = "";
+	TRANSLATION_SELECT_FILE = "";
+	TRANSLATION_NO_MEDIA = ""
+	CONTAINER_CLASS = "pdf-container"
+	METADATA_FORM_ID = "MHL.1070"
+
+	renderMedia = (id: string) => <Thumbnail id={id} apiClient={this.props.formContext.apiClient} apiEndpoint={this.ENDPOINT} />
+	renderLoadingMedia = (id: string) => <Thumbnail dataURL={id} loading={true} apiClient={this.props.formContext.apiClient} apiEndpoint={this.ENDPOINT} />
+	onMediaClick = (i: number) => (this as any).openModalFor(i)
+	renderModalMedia = () => <img src={this.state.modalMediaSrc} />
+
+	formatValue(value: string[], options: any, props: FieldProps) {
+		const {translations} = props.formContext;
+		return value && value.length
+			? `${value.length} ${translations.HowManyFiles}`
+			: null;
+	}
+}

--- a/src/themes/bs5.tsx
+++ b/src/themes/bs5.tsx
@@ -90,7 +90,7 @@ Panel.Collapse = React.forwardRef<typeof Collapse, any>(({children, ...props}, r
 Panel.Footer = Card.Footer;
 
 const Glyphicon: React.ComponentType<GlyphiconProps> = React.forwardRef<SVGSVGElement, GlyphiconProps>(({glyph, ...props}, ref) => (
-	<FontAwesomeIcon icon={iconMapping[glyph]} {...props} ref={ref} />
+	<FontAwesomeIcon className={"glyphicon"} icon={iconMapping[glyph]} {...props} ref={ref} />
 ));
 
 const _Modal: ModalI = Modal as unknown as ModalI;

--- a/src/translations.json
+++ b/src/translations.json
@@ -819,6 +819,11 @@
 		"en": "photos",
 		"sv": "foton"
 	},
+	"howManyFiles": {
+		"fi": "tiedostoa",
+		"en": "files",
+		"sv": "filer"
+	},
 	"sortStrategyDefault": {
 		"fi": "Oletus",
 		"en": "Default",


### PR DESCRIPTION
Adds a new component, `PdfArrayField`, that should work the same as `ImageArrayField` except for pdfs. It can be tested [here](http://localhost:8083/?id=MHL.930&theme=bs5&lang=en) but it won't work correctly because the api doesn't have a pdf endpoint. The pdf endpoint will be added to the Kotka api but probably not to Laji api at least for now. The only way the component could be tested currently is by changing the `ENDPOINT` variable in the code from "pdf" to "images" since the images endpoint also support pdfs.