### PR TITLE
AsArrayField

### DIFF
--- a/src/components/LajiForm.tsx
+++ b/src/components/LajiForm.tsx
@@ -92,6 +92,7 @@ const fields = importLocalComponents<Field>("fields", [
 	"InputWithDefaultValueButtonField",
 	"MultiTagArrayField",
 	"PdfArrayField",
+	"AsArrayField",
 	{"InputTransformerField": "ConditionalOnChangeField"}, // Alias for backward compatibility.
 	{"ConditionalField": "ConditionalUiSchemaField"}, // Alias for backward compatibility.
 	{"UnitRapidField": "UnitShorthandField"}, // Alias for backward compatibility.

--- a/src/components/fields/AsArrayField.tsx
+++ b/src/components/fields/AsArrayField.tsx
@@ -27,9 +27,6 @@ export default class AsArrayField extends React.Component<FieldProps> {
 				},
 				maxItems: 1
 			},
-			uiSchema: props.uiSchema,
-			idSchema: props.idSchema,
-			errorSchema: props.errorSchema,
 			onChange: this.onChange
 		};
 	}

--- a/src/components/fields/AsArrayField.tsx
+++ b/src/components/fields/AsArrayField.tsx
@@ -1,0 +1,40 @@
+import * as React from "react";
+import * as PropTypes from "prop-types";
+import VirtualSchemaField from "../VirtualSchemaField";
+import { FieldProps } from "../LajiForm";
+
+@VirtualSchemaField
+export default class AsArrayField extends React.Component<FieldProps> {
+	static propTypes = {
+		schema: PropTypes.shape({
+			type: PropTypes.oneOf(["array", "object", "string", "integer", "number", "boolean"])
+		}).isRequired,
+		formData: PropTypes.oneOfType([PropTypes.object, PropTypes.array, PropTypes.string, PropTypes.number, PropTypes.bool])
+	}
+
+	static getName() {return "AsArrayField";}
+
+	getStateFromProps(props: FieldProps) {
+		return {
+			...props,
+			formData: props.formData?.length ? [props.formData[0]] : [],
+			schema: {
+				title: props.schema.title,
+				type: "array",
+				items: {
+					...props.schema,
+					title: undefined
+				},
+				maxItems: 1
+			},
+			uiSchema: props.uiSchema,
+			idSchema: props.idSchema,
+			errorSchema: props.errorSchema,
+			onChange: this.onChange
+		};
+	}
+
+	onChange = (formData: any[]) => {
+		this.props.onChange(formData?.[0]);
+	}
+}

--- a/src/components/fields/ImageArrayField.tsx
+++ b/src/components/fields/ImageArrayField.tsx
@@ -5,7 +5,7 @@ import getContext from "../../Context";
 import DropZone from "react-dropzone";
 import { DeleteButton, Button } from "../components";
 import LajiForm from "../LajiForm";
-import { getUiOptions, isObject, updateSafelyWithJSONPointer, parseJSONPointer, JSONPointerToId, updateFormDataWithJSONPointer, idSchemaIdToJSONPointer, getReactComponentName, isDefaultData, parseSchemaFromFormDataPointer, classNames } from "../../utils";
+import { getUiOptions, isObject, updateSafelyWithJSONPointer, parseJSONPointer, JSONPointerToId, updateFormDataWithJSONPointer, idSchemaIdToJSONPointer, getReactComponentName, isDefaultData, parseSchemaFromFormDataPointer, classNames, isNullOrUndefined } from "../../utils";
 import BaseComponent from "../BaseComponent";
 const Spinner = require("react-spinner");
 import * as exif from "exif-js";
@@ -243,6 +243,10 @@ export function MediaArrayField<LFC extends Constructor<React.Component<FieldPro
 
 			const {Row, Col} = this.context.theme;
 			const {DescriptionFieldTemplate} = this.props.registry.templates;
+
+			const mediaCount = (this.props.formData || []).length + (this.state.tmpMedias || []).length;
+			const showAdd = isNullOrUndefined(this.props.schema.maxItems) || mediaCount < this.props.schema.maxItems;
+
 			return (
 				<Row>
 					<Col xs={12}>
@@ -251,7 +255,7 @@ export function MediaArrayField<LFC extends Constructor<React.Component<FieldPro
 						<div className={`laji-form-medias ${this.CONTAINER_CLASS}`}>
 							{this.renderMedias()}
 							{this.renderLoadingMedias()}
-							<OverlayTrigger overlay={tooltip}>
+							{showAdd && <OverlayTrigger overlay={tooltip}>
 								<DropZone accept={this.ACCEPT_FILE_TYPES}
 								          onDragEnter={this.onDragEnter}
 								          onDragLeave={this.onDragLeave}
@@ -276,7 +280,7 @@ export function MediaArrayField<LFC extends Constructor<React.Component<FieldPro
 										);
 									}}
 								</DropZone>
-							</OverlayTrigger>
+							</OverlayTrigger>}
 							{this.renderMetadataModal()}
 							{this.renderMediaAddModal()}
 						</div>


### PR DESCRIPTION
Adds a new field `AsArrayField` that converts schema and form data into an array which for example makes it possible to use `MediaArrayField` with non-array fields. Can be tested here http://localhost:8083/?id=MHL.930&theme=bs5&lang=en with the permits file field but it doesn't work correctly without Kotka api client.