### PR TITLE
Fix ApiClient throws an error with 204 (no content) responses

### DIFF
--- a/src/ApiClient.ts
+++ b/src/ApiClient.ts
@@ -52,6 +52,9 @@ export default class ApiClient {
 			if (!failSilently && response.status >= 400) {
 				throw new Error("Request failed");
 			}
+			if (response.status === 204) {
+				return undefined as unknown as T;
+			}
 			return response.json() as T;
 		}).catch(() => {
 			if (this.cache[path]) delete this.cache[path][this.getCacheKey(query, options)];


### PR DESCRIPTION
The 204 response doesn't necessary contain a body and in that case the ApiClient throws an error when it tries to call the `.json()` function