### PR TITLE
AudioArrayField acceps flac files

### DIFF
--- a/src/components/fields/AudioArrayField.js
+++ b/src/components/fields/AudioArrayField.js
@@ -5,7 +5,7 @@ import * as Spinner from "react-spinner";
 import { GlyphButton } from "../components";
 import ReactContext from "../../ReactContext";
 
-const FILE_TYPES = ["audio/mp3", "audio/mpeg", "audio/x-wav", "audio/wav", "audio/wave", "audio/vnd.wave"];
+const FILE_TYPES = ["audio/mp3", "audio/mpeg", "audio/x-wav", "audio/wav", "audio/wave", "audio/vnd.wave", "audio/flac"];
 
 @MediaArrayField
 export default class AudioArrayField extends React.Component {
@@ -82,10 +82,12 @@ const AudioButton = React.forwardRef((props, ref) => {
 const LajiAudio = React.forwardRef((props, ref) => {
 	const [mp3Url, setMp3Url] = useState(null);
 	const [wavUrl, setWavUrl] = useState(null);
+	const [flacUrl, setFlacUrl] = useState(null);
 	useEffect(() => {
 		props.apiClient.fetchCached(`/audio/${props.id}`, undefined, {failSilently: true}).then(response => {
 			setMp3Url(response.mp3URL);
 			setWavUrl(response.wavURL);
+			setFlacUrl(response.flacURL);
 			props.onLoaded && props.onLoaded(true);
 		});
 	});
@@ -101,7 +103,12 @@ const LajiAudio = React.forwardRef((props, ref) => {
 								<a href={wavUrl} download>{`${props.translations.Download} wav`}</a>
 							</React.Fragment>
 					}
-
+					{flacUrl &&
+						<React.Fragment>
+							{" | "}
+							<a href={flacUrl} download>{`${props.translations.Download} flac`}</a>
+						</React.Fragment>
+					}
 				</React.Fragment>
 			)}
 		</div>

--- a/src/components/fields/AudioArrayField.js
+++ b/src/components/fields/AudioArrayField.js
@@ -104,10 +104,10 @@ const LajiAudio = React.forwardRef((props, ref) => {
 							</React.Fragment>
 					}
 					{flacUrl &&
-						<React.Fragment>
-							{" | "}
-							<a href={flacUrl} download>{`${props.translations.Download} flac`}</a>
-						</React.Fragment>
+							<React.Fragment>
+								{" | "}
+								<a href={flacUrl} download>{`${props.translations.Download} flac`}</a>
+							</React.Fragment>
 					}
 				</React.Fragment>
 			)}

--- a/src/components/fields/AudioArrayField.js
+++ b/src/components/fields/AudioArrayField.js
@@ -12,7 +12,7 @@ export default class AudioArrayField extends React.Component {
 	static contextType = ReactContext;
 	ALLOWED_FILE_TYPES = FILE_TYPES;
 	ACCEPT_FILE_TYPES = ["audio/*"];
-	MAX_FILE_SIZE = 20000000;
+	MAX_FILE_SIZE = 100000000;
 	KEY = "AUDIO";
 	ENDPOINT = "audio";
 	GLYPH = "headphones";


### PR DESCRIPTION
Can be tested by setting the api base url to https://dev.laji.fi/api (only the old api has flac support at the moment) and adding a flac audio file in the trip form http://localhost:8083/?id=JX.519. 