### PR TITLE
Autosuggest empty value fix

### DIFF
--- a/src/components/templates/ErrorListTemplate.js
+++ b/src/components/templates/ErrorListTemplate.js
@@ -64,7 +64,7 @@ export default class ErrorListTemplate extends React.Component {
 				let _path = path;
 				if (prop.match(/^\d+$/)) _path = `${_path}/items`;
 				else _path = `${_path}/properties/${prop}`;
-				const _defaultTitle = uiSchema["ui:multiLanguage"] ? `${title} (${prop})` : prop;
+				const _defaultTitle = _schema.type === "array" || uiSchema["ui:multiLanguage"] ? `${title} (${prop})` : prop;
 				const childErrors = walkErrors(_path, `${id}_${prop}`, errorSchema[prop], uiSchema[prop] || {}, _defaultTitle);
 				errors = [...errors, ...childErrors.errors];
 				warnings = [...warnings, ...childErrors.warnings];

--- a/src/components/widgets/AutosuggestWidget.js
+++ b/src/components/widgets/AutosuggestWidget.js
@@ -729,7 +729,7 @@ export class Autosuggest extends React.Component {
 		} else if (!valueDidntChangeAndHasInformalTaxonGroup && allowNonsuggestedValue) {
 			this.selectUnsuggested(parsedInputValue);
 		} else if (!allowNonsuggestedValue) {
-			this.setState({inputValue: ""}, () => this.props.onChange && this.props.onChange(""));
+			this.setState({inputValue: ""}, () => this.props.onChange && this.props.onChange(undefined));
 		}
 
 		callback && callback();

--- a/src/components/widgets/AutosuggestWidget.js
+++ b/src/components/widgets/AutosuggestWidget.js
@@ -580,8 +580,10 @@ export class Autosuggest extends React.Component {
 			: afterStateChange();
 	}
 
-	selectUnsuggested = (value) => {
-		if (isEmptyString(value) && isEmptyString(this.props.value)) return;
+	selectUnsuggested = (inputValue) => {
+		if (isEmptyString(inputValue) && isEmptyString(this.props.value)) return;
+
+		const value = !isEmptyString(inputValue) ? inputValue : undefined;
 
 		const {onUnsuggestedSelected, onChange} = this.props;
 
@@ -591,7 +593,7 @@ export class Autosuggest extends React.Component {
 				onChange(value);
 		};
 
-		const state = {inputValue: value, suggestion: undefined, suggestionForValue: value};
+		const state = {inputValue, suggestion: undefined, suggestionForValue: inputValue};
 		this.mounted
 			? this.setState(state, afterStateChange)
 			: afterStateChange();

--- a/test/test-utils.ts
+++ b/test/test-utils.ts
@@ -217,6 +217,7 @@ export class Form {
 			$input: this.$locate(lajiFormLocator).locator("input"),
 			$suggestionsContainer: this.$locate(lajiFormLocator).locator(".rw-list"),
 			$suggestions: this.$locate(lajiFormLocator).locator(".rw-list-option"),
+			$loadingSpinner: this.$locate(lajiFormLocator).locator(".react-spinner"),
 		};
 	}
 

--- a/test/trip-report-autosuggest.spec.ts
+++ b/test/trip-report-autosuggest.spec.ts
@@ -54,6 +54,13 @@ test.describe("Trip report (JX.519) autosuggestions", () => {
 			await expect(censusAutosuggest.$suggestedGlyph).toBeVisible();
 			await expect(censusAutosuggest.$input).toHaveValue("Aves");
 		});
+
+		test("sets empty value undefined", async () => {
+			await censusAutosuggest.$input.clear();
+			await censusAutosuggest.$input.press("Enter");
+			await expect(censusAutosuggest.$loadingSpinner).not.toBeVisible();
+			expect((await form.getChangedData()).gatherings[0].taxonCensus[0].censusTaxonID).toBe(undefined);
+		});
 	});
 
 	test.describe("unit taxon", () => {


### PR DESCRIPTION
Changed the autosuggest widget so that if it has an `allowNonsuggestedValue` as false then the empty value is undefined instead of an empty string. Also added a more descriptive title for the array item errors as the title was only the number previously.