### PR TITLE
Added HiddenWithTextField

### DIFF
--- a/src/components/LajiForm.tsx
+++ b/src/components/LajiForm.tsx
@@ -50,6 +50,7 @@ const fields = importLocalComponents<Field>("fields", [
 	"AutoArrayField",
 	"AutosuggestField",
 	"HiddenField",
+	"HiddenWithTextField",
 	"InitiallyHiddenField",
 	"ContextInjectionField",
 	"ImageArrayField",

--- a/src/components/fields/HiddenWithTextField.tsx
+++ b/src/components/fields/HiddenWithTextField.tsx
@@ -1,0 +1,23 @@
+import * as React from "react";
+import * as PropTypes from "prop-types";
+import { FieldProps, JSONSchemaArray, JSONSchemaString } from "../../types";
+
+const HiddenWithTextField = (props: FieldProps<JSONSchemaArray<JSONSchemaString>>) => {
+	return (
+		<div>{props.uiSchema["ui:options"]?.altText}</div>
+	);
+};
+
+HiddenWithTextField.propTypes = {
+	uiSchema: PropTypes.shape({
+		"ui:options": PropTypes.shape({
+			"altText": PropTypes.string.isRequired
+		}).isRequired,
+		uiSchema: PropTypes.object
+	}).isRequired,
+	schema: PropTypes.shape({
+		type: PropTypes.oneOf(["object", "array", "string", "number", "boolean", "integer"])
+	}).isRequired
+};
+
+export default HiddenWithTextField;


### PR DESCRIPTION
New field HiddenTextField can be used when replacing content with text, using ConditionalUiSchemaField. First I tried to add altText as HiddenField param, but that didn't accept ui:classNames, which is required to style the altText.