### PR TITLE
Specimen form improvements 4

### DIFF
--- a/forms/MHL.1158.json
+++ b/forms/MHL.1158.json
@@ -3464,7 +3464,14 @@
     "images": {
       "ui:field": "ImageArrayField",
       "ui:options": {
-        "metadataFormId": "MHL.1160"
+        "metadataFormId": "MHL.1160",
+        "exifParsers": [
+          {
+            "field": "/captureDateTime",
+            "parse": "date",
+            "type": "mutateMetadata"
+          }
+        ]
       }
     },
     "owner": {

--- a/playground/styles.css
+++ b/playground/styles.css
@@ -167,7 +167,7 @@ body .laji-form {
 	margin-bottom: 6px;
 }
 
-.laji-form button {
+.laji-form button, .laji-form .page-link {
 	line-height: 14px;
 	white-space: normal;
 }
@@ -703,7 +703,7 @@ body .laji-form {
 	padding: 10px 15px;
 	color: rgb(51, 51, 51);
 }
-.laji-form .laji-form-panel .panel-heading, .laji-form .pager {
+.laji-form .laji-form-panel .panel-heading, .laji-form .pager, .laji-form .pagination {
 	padding: 0;
 	margin: 0;
 }

--- a/src/components/LajiForm.tsx
+++ b/src/components/LajiForm.tsx
@@ -187,7 +187,7 @@ export interface LajiFormProps extends HasMaybeChildren {
 	topOffset?: number;
 	bottomOffset?: number;
 	formContext?: any;
-	uiSchemaContext?: any;
+	uiSchemaContext?: UiSchemaContext;
 	settings?: any;
 	id?: string;
 	googleApiKey?: string;
@@ -263,6 +263,15 @@ export interface FormContext {
 		singletonMap: SingletonMapService,
 		multiActiveArray: MultiActiveArrayService
 	}
+}
+
+export interface UiSchemaContext {
+	isAdmin?: boolean;
+	isEdit?: boolean;
+	creator?: string;
+	confirmDelete?: boolean;
+	additionalClassNames?: Record<string, string>;
+	[key: string]: any;
 }
 
 export type NotifyMessager = (msg: string) => void;

--- a/src/components/LajiForm.tsx
+++ b/src/components/LajiForm.tsx
@@ -223,7 +223,7 @@ export interface LajiFormState {
 }
 
 export interface MediaMetadata {
-	capturerVerbatim: string;
+	capturerVerbatim?: string|string[];
 	intellectualOwner: string;
 	intellectualRights: string;
 }

--- a/src/components/fields/CondensedObjectField.tsx
+++ b/src/components/fields/CondensedObjectField.tsx
@@ -147,8 +147,22 @@ export default class CondensedObjectField extends React.Component<FieldProps<JSO
 	render() {
 		const SchemaField = this.props.registry.fields.SchemaField as any;
 
-		const {schema, uiSchema, idSchema, errorSchema, formData = {}, required, formContext: {Label, translations}} = this.props;
-		const uiOptions = getUiOptions(uiSchema);
+		const {
+			schema,
+			uiSchema,
+			idSchema,
+			errorSchema,
+			formData = {},
+			required,
+			disabled,
+			readonly,
+			formContext: {Label, translations, uiSchemaContext}
+		} = this.props;
+
+		const {
+			addFieldPlaceholder = `${translations.AddField}`,
+			confirmDelete = uiSchemaContext.confirmDelete
+		} = getUiOptions(uiSchema);
 
 		const childProps: Pick<FieldProps<any, any>, "schema"|"uiSchema"|"idSchema"|"errorSchema"|"formData">[] = this.state.selectedFields.map(field => {
 			let childSchema = schema.properties[field.name];
@@ -189,8 +203,6 @@ export default class CondensedObjectField extends React.Component<FieldProps<JSO
 			label: schema.properties[prop].title || prop,
 		}));
 
-		const addFieldPlaceholder = uiOptions.addFieldPlaceholder ?? `${translations.AddField}`;
-
 		return (
 			<>
 				<Label label={this.props.schema.title} required={required || uiSchema["ui:required"]} id={this.props.idSchema.$id} uiSchema={this.props.uiSchema} />
@@ -209,6 +221,8 @@ export default class CondensedObjectField extends React.Component<FieldProps<JSO
 								id={props.idSchema.$id}
 								onClick={this.onFieldDelete(idx)}
 								translations={translations}
+								confirm={confirmDelete}
+								disabled={disabled || readonly}
 							/>
 						</div>
 					</div>

--- a/src/components/fields/ImageArrayField.tsx
+++ b/src/components/fields/ImageArrayField.tsx
@@ -41,6 +41,11 @@ interface MediaMetadataSchema {
 	intellectualRights?: string
 }
 
+interface ProcessedExifData {
+	formData?: any;
+	defaultMediaMetadata?: any;
+}
+
 @MediaArrayField
 export default class ImageArrayField extends React.Component<FieldProps<any, JSONSchemaArray<JSONSchemaObject>>, ImageArrayFieldState> {
 	ALLOWED_FILE_TYPES = ["image/jpeg", "image/png", "image/bmp", "image/tiff", "image/gif"];
@@ -475,9 +480,9 @@ export function MediaArrayField<LFC extends Constructor<React.Component<FieldPro
 			this.setState({alert: false, alertMsg: undefined});
 		};
 
-		parseExif = (files: File[]): undefined | Promise<any> => {
+		parseExif = (files: File[]): Promise<ProcessedExifData> => {
 			const {exifParsers = []} = getUiOptions(this.props.uiSchema);
-			if (!exifParsers) return;
+			if (!exifParsers) return Promise.resolve({});
 
 			const found = exifParsers.reduce((found: any, {parse} : {parse: string}) => {
 				found[parse] = false;
@@ -543,15 +548,21 @@ export function MediaArrayField<LFC extends Constructor<React.Component<FieldPro
 				const lajiFormInstance = this.props.formContext.services.rootInstance;
 				const schema = lajiFormInstance.getSchema();
 				let formData = lajiFormInstance.getFormData();
+				let defaultMediaMetadata: any = {};
+
 				exifParsers.filter((f: any) => f.type === "event" || found[f.parse]).forEach(({field, parse, type, eventName}: any) => {
 					if (type === "mutate") {
 						formData = updateFormDataWithJSONPointer({formData, schema, registry}, found[parse], field);
+					}
+					if (type === "mutateMetadata") {
+						defaultMediaMetadata = updateSafelyWithJSONPointer(defaultMediaMetadata, found[parse], field);
 					}
 					if (type === "event") {
 						this.props.formContext.services.customEvents.send(`root_${JSONPointerToId(field)}`, eventName, found[parse], undefined, {bubble: false});
 					}
 				});
-				return formData;
+
+				return { formData, defaultMediaMetadata };
 			});
 		};
 
@@ -590,12 +601,17 @@ export function MediaArrayField<LFC extends Constructor<React.Component<FieldPro
 				this.setState({addModal: undefined});
 			}
 
-			this.parseExif(files)?.then(this.sideEffects);
+			const exifDataPromise = this.parseExif(files);
+			exifDataPromise.then(data => {
+				if (data.formData) {
+					this.sideEffects(data.formData);
+				}
+			});
 
 			const id = this.getContainerId();
-
 			const lajiFormInstance = this.props.formContext.services.rootInstance;
-			const saveAndOnChange = () => this.saveMedias(files).then(mediaIds => {
+
+			const saveAndOnChange = () => this.saveMedias(files, exifDataPromise).then(mediaIds => {
 				if (!lajiFormInstance.isMounted() || !mediaIds) {
 					return;
 				}
@@ -640,7 +656,7 @@ export function MediaArrayField<LFC extends Constructor<React.Component<FieldPro
 			return _parentLajiFormId;
 		};
 
-		async saveMedias(files: File[]) {
+		async saveMedias(files: File[], exifDataPromise: Promise<ProcessedExifData>) {
 			const containerId = this.getContainerId();
 			let tmpMedias: number[] = [];
 
@@ -689,7 +705,7 @@ export function MediaArrayField<LFC extends Constructor<React.Component<FieldPro
 				}
 
 				const tmpMediaEntities = await this.apiClient.post(`/${this.ENDPOINT}` as any, undefined, formData as any) as any;
-				const mediaMetadata = await this.getMetadataPromise();
+				const mediaMetadata = await this.getMetadataPromise(exifDataPromise);
 				const mediaEntities = await Promise.all(tmpMediaEntities.map((item: any) => 
 					this.apiClient.post(`/${this.ENDPOINT}/{id}` as any, { path: { id: item.id } }, mediaMetadata as any)
 				));
@@ -750,13 +766,13 @@ export function MediaArrayField<LFC extends Constructor<React.Component<FieldPro
 			}
 		};
 
-		getMetadataPromise = (): Promise<MediaMetadataSchema> => {
-			let mediaMetadata : any =
+		getMetadataPromise = (exifDataPromise: Promise<ProcessedExifData>): Promise<MediaMetadataSchema> => {
+			let mediaMetadata : Record<string, any> =
 				this.props.formContext.mediaMetadata
 				|| {intellectualRights: "MZ.intellectualRightsARR"};
 			const MACode = this.props.formContext.uiSchemaContext.creator;
 
-			return ("capturerVerbatim" in mediaMetadata)
+			const metadataPromise = ("capturerVerbatim" in mediaMetadata)
 				? Promise.resolve({...mediaMetadata, capturerVerbatim: [mediaMetadata.capturerVerbatim]})
 				: MACode
 					? this.apiClient.get("/person/by-id/{personId}", { path: { personId: MACode } }).then(({fullName = MACode}) => (
@@ -766,7 +782,11 @@ export function MediaArrayField<LFC extends Constructor<React.Component<FieldPro
 							intellectualOwner: fullName
 						}
 					)).catch(() => Promise.resolve(mediaMetadata))
-					: mediaMetadata;
+					: Promise.resolve(mediaMetadata);
+
+			return Promise.all([exifDataPromise, metadataPromise]).then(([exifData, metadata]) => {
+				return { ...exifData.defaultMediaMetadata, ...metadata };
+			});
 		};
 
 		getMaxFileSizeAsString = () => {

--- a/src/components/fields/ImageArrayField.tsx
+++ b/src/components/fields/ImageArrayField.tsx
@@ -773,7 +773,10 @@ export function MediaArrayField<LFC extends Constructor<React.Component<FieldPro
 			const MACode = this.props.formContext.uiSchemaContext.creator;
 
 			const metadataPromise = ("capturerVerbatim" in mediaMetadata)
-				? Promise.resolve({...mediaMetadata, capturerVerbatim: [mediaMetadata.capturerVerbatim]})
+				? Promise.resolve({
+					...mediaMetadata,
+					capturerVerbatim: Array.isArray(mediaMetadata.capturerVerbatim) ? mediaMetadata.capturerVerbatim : [mediaMetadata.capturerVerbatim]
+				})
 				: MACode
 					? this.apiClient.get("/person/by-id/{personId}", { path: { personId: MACode } }).then(({fullName = MACode}) => (
 						{

--- a/src/components/fields/PrefixArrayField.tsx
+++ b/src/components/fields/PrefixArrayField.tsx
@@ -77,8 +77,8 @@ export default class PrefixArrayField extends React.Component<FieldProps<JSONSch
 	render() {
 		const SchemaField = this.props.registry.fields.SchemaField as any;
 
-		const {schema, uiSchema, idSchema, errorSchema, required, formContext: {Label, translations}} = this.props;
-		const {prefixValues = [], addFieldPlaceholder} = getUiOptions(uiSchema);
+		const {schema, uiSchema, idSchema, errorSchema, required, disabled, readonly, formContext: {Label, translations, uiSchemaContext}} = this.props;
+		const {prefixValues = [], addFieldPlaceholder, confirmDelete = uiSchemaContext.confirmDelete} = getUiOptions(uiSchema);
 
 		const childProps: Pick<FieldProps<any, any>, "schema"|"uiSchema"|"idSchema"|"errorSchema"|"formData">[] = this.state.fieldValues.map((value: FieldValue, idx: number) => {
 			return {
@@ -121,6 +121,8 @@ export default class PrefixArrayField extends React.Component<FieldProps<JSONSch
 								id={props.idSchema.$id}
 								onClick={this.onFieldDelete(idx)}
 								translations={translations}
+								confirm={confirmDelete}
+								disabled={disabled || readonly}
 							/>
 						</div>
 					</div>

--- a/src/components/fields/SectionArrayField.js
+++ b/src/components/fields/SectionArrayField.js
@@ -264,6 +264,7 @@ class SectionArrayFieldTemplate extends React.Component {
 					id={`${this.props.idSchema.$id}_${index}`}
 					disabled={disabled || readonly}
 					translations={this.props.formContext.translations}
+					confirm={this.props.formContext.uiSchemaContext.confirmDelete}
 					onClick={onDropIndexClick(index)}
 					className="horizontally-centered" />
 			);

--- a/src/components/fields/SingleActiveArrayField.js
+++ b/src/components/fields/SingleActiveArrayField.js
@@ -518,8 +518,8 @@ export class AccordionArrayFieldTemplate extends React.Component {
 
 		const activeIdx = that.state.activeIdx;
 
-		const {confirmDelete, closeButton, affixed} = getUiOptions(arrayFieldTemplateProps.uiSchema);
-		const {translations} = this.props.formContext;
+		const {translations, uiSchemaContext} = this.props.formContext;
+		const {confirmDelete = uiSchemaContext.confirmDelete, closeButton, affixed} = getUiOptions(arrayFieldTemplateProps.uiSchema);
 		const {disabled, readonly} = arrayFieldTemplateProps;
 
 		const containerRefs = {};
@@ -604,9 +604,9 @@ class PagerArrayFieldTemplate extends React.Component {
 
 	render() {
 		const that = this.props.formContext.this;
-		const	arrayTemplateFieldProps = this.props;
-		const {translations} = that.props.formContext;
-		const {buttons, affixed, headerClassName, confirmDelete} = getUiOptions(arrayTemplateFieldProps.uiSchema);
+		const arrayTemplateFieldProps = this.props;
+		const {translations, uiSchemaContext} = that.props.formContext;
+		const {buttons, affixed, headerClassName, confirmDelete = uiSchemaContext.confirmDelete} = getUiOptions(arrayTemplateFieldProps.uiSchema);
 		const activeIdx = that.state.activeIdx;
 
 		const {Pager} = this.context.theme;
@@ -972,7 +972,7 @@ class TableArrayFieldTemplate extends React.Component {
 		const {errorSchema} = that.props;
 		const activeIdx = that.state.activeIdx;
 
-		const {confirmDelete} = getUiOptions(uiSchema);
+		const {confirmDelete = this.props.formContext.uiSchemaContext.confirmDelete} = getUiOptions(uiSchema);
 
 		const getDeleteButtonFor = (idx, item) => {
 			return removable && <DeleteButton id={`${that.props.idSchema.$id}_${idx}`} 

--- a/src/components/fields/TableField.js
+++ b/src/components/fields/TableField.js
@@ -133,7 +133,7 @@ class TableArrayFieldTemplate extends React.Component {
 	static contextType = ReactContext;
 	render() {
 		const {props} = this;
-		const {schema, uiSchema, formContext: {cols, wrapperCols, schemaPropsArray}, idSchema, readonly, disabled} = props;
+		const {schema, uiSchema, formContext: {cols, wrapperCols, schemaPropsArray, uiSchemaContext}, idSchema, readonly, disabled} = props;
 		const schemaProps = schema.additionalItems ? schema.additionalItems.properties : schema.items.properties;
 		const {Label} = this.props.formContext;
 		const {Row, Col} = this.context.theme;
@@ -156,7 +156,7 @@ class TableArrayFieldTemplate extends React.Component {
 		});
 
 		const options = getUiOptions(props.uiSchema);
-		const {confirmDelete, deleteCorner, removable = true, nonRemovables = [], buttons, "ui:deleteHelp": deleteHelp} = options;
+		const {confirmDelete = uiSchemaContext.confirmDelete, deleteCorner, removable = true, nonRemovables = [], buttons, "ui:deleteHelp": deleteHelp} = options;
 		if (!this.deleteButtonRefs) this.deleteButtonRefs = [];
 
 		const getRefFor = i => elem => {this.deleteButtonRefs[i] = elem;};

--- a/src/components/templates/ArrayFieldTemplate.js
+++ b/src/components/templates/ArrayFieldTemplate.js
@@ -278,8 +278,10 @@ export class ArrayFieldTemplateWithoutKeyHandling extends React.Component {
 
 	render() {
 		const {props} = this;
+		const {readonly, disabled} = this.props;
+		const {Label, uiSchemaContext} = this.props.formContext;
 		const {
-			confirmDelete,
+			confirmDelete = uiSchemaContext.confirmDelete,
 			renderTitleAsLabel,
 			deleteCorner,
 			removable = true,
@@ -289,10 +291,10 @@ export class ArrayFieldTemplateWithoutKeyHandling extends React.Component {
 			"ui:deleteHelp": deleteHelp,
 			buttons = []
 		} = getUiOptions(props.uiSchema);
-		const {readonly, disabled} = this.props;
-		const {Label} = this.props.formContext;
+
 		const Title = renderTitleAsLabel ? Label : getTemplate("TitleFieldTemplate", props.registry, getUiOptions(props.uiSchema));
 		const Description = getTemplate("DescriptionFieldTemplate", this.props.registry, getUiOptions(props.uiSchema));
+
 		if (!this.deleteButtonRefs) this.deleteButtonRefs = [];
 
 		const _buttons = getButtons(buttons, props);
@@ -301,7 +303,6 @@ export class ArrayFieldTemplateWithoutKeyHandling extends React.Component {
 		const bottomButtons = getButtonsElem(getButtonsForPosition(props, _buttons, "bottom"), props);
 
 		const getRefFor = i => elem => {this.deleteButtonRefs[i] = elem;};
-
 
 		const items = props.items.map((item, i) => {
 			const getDeleteButton = () => (

--- a/src/themes/bs5.tsx
+++ b/src/themes/bs5.tsx
@@ -26,7 +26,8 @@ import {
 	Dropdown,
 	Form,
 	ToggleButton,
-	ToggleButtonGroup
+	ToggleButtonGroup,
+	PageItem
 } from "react-bootstrap-5";
 import { Variant, ButtonVariant } from "react-bootstrap-5/types";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
@@ -39,6 +40,8 @@ import {
 	Dropdown as DropdownI,
 	PanelProps,
 	Panel as PanelI,
+	Pager as PagerI,
+	PagerItemProps,
 	GlyphiconProps,
 	ListGroupProps,
 	Variant as VariantI,
@@ -76,7 +79,7 @@ const mapValidationStateToClass = (validationState?: ValidationState|null): stri
 	return "text-" + (validationState === "error" ? "danger" : validationState);
 };
 
-const _Card = React.forwardRef<HTMLDivElement, PanelProps>((props, ref) => (
+const _Card = React.forwardRef<HTMLDivElement, PanelProps>(({eventKey, ...props}, ref) => (
 	<Card {...props} ref={ref} />
 ));
 let Panel = _Card as unknown as PanelI;
@@ -114,6 +117,11 @@ const _Popover = React.forwardRef<typeof Popover, any>(({children, ...props}, re
 	</Popover>
 ));
 
+const _Pager: PagerI = Pagination;
+_Pager.Item = React.forwardRef<HTMLLIElement, PagerItemProps>(({previous, next, ...props}, ref) => (
+	<PageItem {...props} ref={ref} />
+));
+
 const theme: Theme = {
 	Panel,
 	Table,
@@ -138,7 +146,7 @@ const theme: Theme = {
 	HelpBlock: React.forwardRef<HTMLElement, JSX.IntrinsicAttributes>((props, ref) => <Form.Text {...props} ref={ref} />),
 	MenuItem: Dropdown.Item,
 	Alert: React.forwardRef<HTMLDivElement, AlertProps>(({variant, ...props}, ref) => <Alert variant={mapVariant(variant)} {...props} ref={ref} />),
-	Pager: Pagination,
+	Pager: _Pager,
 	Accordion: React.forwardRef<typeof Accordion, AccordionProps>((props, ref) => <Accordion {...props as any} ref={ref} />),
 	Collapse,
 	Dropdown: _Dropdown,


### PR DESCRIPTION
This contain changes to `MediaArrayField`
- `exifParsers` can include a parser that mutates the media metadata
- metadata field `capturerVerbatim` can be empty or an array
- style fixes for bs5 theme

This also adds `confirmDelete` option to the `uiSchemaContext` that allows setting a default value for the `confirmDelete` option that is used in many array fields.