### PR TITLE
Added error schema type guard for filteredErrors

### DIFF
--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -1109,6 +1109,9 @@ export function highlightElem(elem?: Element) {
 }
 
 export function filteredErrors(errorSchema: any) {
+	if (!errorSchema || typeof errorSchema !== "object") {
+		return {};
+	}
 	return Object.keys(errorSchema).reduce<any>((_errorSchema, prop) => {
 		if (prop === "__errors") {
 			if (errorSchema.__errors.length) {


### PR DESCRIPTION
When crossCheck validation triggers for empty unitFact, it returns errorSchema as string, which causes an error in filteredErrors() function that expects type object. Adding a guard fixes this.