### PR TITLE
Remove empty objects before submit

### DIFF
--- a/src/components/LajiForm.tsx
+++ b/src/components/LajiForm.tsx
@@ -746,45 +746,45 @@ export default class LajiForm extends React.Component<LajiFormProps, LajiFormSta
 
 		let schemaErrors = toErrorSchema(errors);
 
-		const removedPaths = this.getFormDataReadyForSubmit(formData, this.props.schema).removedPaths;
-		removedPaths.forEach(path => {
+		const ignoreErrorPaths = this.getFormDataReadyForSubmit(formData, this.props.schema).removedArrayItemsAndObjects;
+		ignoreErrorPaths.forEach(path => {
 			schemaErrors = immutableDelete(schemaErrors, path);
 		});
 
 		return schemaErrors;
 	};
 
-	getFormDataReadyForSubmit = (formData: any, schema: JSONSchema): { formData: any, removedPaths: string[] } => {
+	getFormDataReadyForSubmit = (formData: any, schema: JSONSchema): { formData: any, removedArrayItemsAndObjects: string[] } => {
 		formData = this.memoizedFormContext.services.ids.removeLajiFormIds(formData);
 		return removeEmptyValuesAndTrim(formData, schema);
 	};
 }
 
 
-const removeEmptyValuesAndTrim = (formData: any, schema: JSONSchema): { formData: any, removedPaths: string[] } => {
-	const removedPaths: string[] = [];
+const removeEmptyValuesAndTrim = (formData: any, schema: JSONSchema): { formData: any, removedArrayItemsAndObjects: string[] } => {
+	const removedArrayItemsAndObjects: string[] = [];
 
 	return {
 		formData: removeRecursive(formData, schema, true, ""),
-		removedPaths
+		removedArrayItemsAndObjects
 	};
 
 	function removeRecursive(formData: any, schema: JSONSchema | undefined, isRequired: boolean, path: string): any {
 		if (schema && isJSONSchemaObject(schema) && isObject(formData)) {
 			const object = Object.keys(formData).reduce((obj, k) => {
-				const value = removeRecursive(formData[k], schema.properties[k], schema.required?.includes(k) || false, `${path}/${k}`);
+				const childSchema = schema.properties[k];
+				const value = removeRecursive(formData[k], childSchema, schema.required?.includes(k) || false, `${path}/${k}`);
+
 				if (value !== undefined) {
 					obj[k] = value;
+				} else if (childSchema && isJSONSchemaObject(childSchema)) {
+					removedArrayItemsAndObjects.push(`${path}/${k}`);
 				}
+
 				return obj;
 			}, {} as Record<string, unknown>);
 
-			if (isRequired || Object.keys(object).length > 0) {
-				return object;
-			} else {
-				removedPaths.push(path);
-				return undefined;
-			}
+			return isRequired || Object.keys(object).length > 0 ? object : undefined;
 		} else if (schema && isJSONSchemaArray(schema) && Array.isArray(formData)) {
 			const nonEmptyItems: Record<number, any> = {};
 			formData.forEach((item, idx) => {
@@ -804,7 +804,7 @@ const removeEmptyValuesAndTrim = (formData: any, schema: JSONSchema): { formData
 					arr.push(removeRecursive(item, schema.items, true, childPath));
 					missingItems--;
 				} else {
-					removedPaths.push(childPath);
+					removedArrayItemsAndObjects.push(childPath);
 				}
 				return arr;
 			}, []);

--- a/src/components/LajiForm.tsx
+++ b/src/components/LajiForm.tsx
@@ -15,8 +15,7 @@ import {
 	ReactUtils,
 	ReactUtilsType,
 	JSONPointerToId,
-	isObject,
-	immutableDelete
+	isObject
 } from "../utils";
 const equals = require("deep-equal");
 import rjsfValidator from "@rjsf/validator-ajv6";
@@ -483,14 +482,16 @@ export default class LajiForm extends React.Component<LajiFormProps, LajiFormSta
 	};
 
 	validateAndSubmit = (warnings = true, onlySchema = false) => {
-		const {formData} = this.state;
+		let {formData} = this.state;
 		const {onValidationError, onSubmit, schema} = this.props;
 		this.setState({ externalErrors: undefined });
 		return this.validate(warnings, true, onlySchema).then(valid => {
 			if (formData !== this.state.formData) {
 				this.validateAndSubmit(warnings, onlySchema);
 			} else if (valid) {
-				onSubmit?.({formData: this.getFormDataReadyForSubmit(formData, schema)});
+				formData = this.getFormDataReadyForSubmit(formData, schema);
+				this.setState({ formData });
+				onSubmit?.({ formData });
 			} else {
 				onValidationError && onValidationError(this.state.extraErrors!);
 			}

--- a/src/components/LajiForm.tsx
+++ b/src/components/LajiForm.tsx
@@ -490,7 +490,7 @@ export default class LajiForm extends React.Component<LajiFormProps, LajiFormSta
 			if (formData !== this.state.formData) {
 				this.validateAndSubmit(warnings, onlySchema);
 			} else if (valid) {
-				onSubmit?.({formData: this.getFormDataReadyForSubmit(formData, schema).formData});
+				onSubmit?.({formData: this.getFormDataReadyForSubmit(formData, schema)});
 			} else {
 				onValidationError && onValidationError(this.state.extraErrors!);
 			}
@@ -509,9 +509,7 @@ export default class LajiForm extends React.Component<LajiFormProps, LajiFormSta
 
 		const block = nonlive || onlySchema;
 
-		const { schema } = this.props;
 		const { formData } = this.state;
-		const removedArrayPaths = this.getFormDataReadyForSubmit(formData, schema).removedArrayPaths;
 
 		const {live: liveErrorValidators, rest: errorValidators} =
 			splitLive(this.props.validators, this.props.schema.properties);
@@ -549,9 +547,6 @@ export default class LajiForm extends React.Component<LajiFormProps, LajiFormSta
 					this.state.externalErrors || {},
 					mergedInternalErrors as any
 				) as any;
-				removedArrayPaths.forEach(path => {
-					mergedAll = immutableDelete(mergedAll, path);
-				});
 				this.validating = false;
 				resolve(!Object.keys(mergedAll).length);
 				if (!equals((this.state.extraErrors || {}), mergedAll)) {
@@ -749,20 +744,15 @@ export default class LajiForm extends React.Component<LajiFormProps, LajiFormSta
 		return toErrorSchema(errors);
 	};
 
-	getFormDataReadyForSubmit = (formData: any, schema: JSONSchema): { formData: any, removedArrayPaths: string[] } => {
+	getFormDataReadyForSubmit = (formData: any, schema: JSONSchema): any => {
 		formData = this.memoizedFormContext.services.ids.removeLajiFormIds(formData);
 		return removeEmptyValuesAndTrim(formData, schema);
 	};
 }
 
 
-const removeEmptyValuesAndTrim = (formData: any, schema: JSONSchema): { formData: any, removedArrayPaths: string[] } => {
-	const removedArrayPaths: string[] = [];
-	
-	return {
-		formData: removeRecursive(formData, schema, true, ""),
-		removedArrayPaths
-	};	
+const removeEmptyValuesAndTrim = (formData: any, schema: JSONSchema): any => {
+	return removeRecursive(formData, schema, true, "");
 
 	function removeRecursive(formData: any, schema: JSONSchema | undefined, isRequired: boolean, path: string): any {
 		if (schema && isJSONSchemaObject(schema) && isObject(formData)) {
@@ -776,25 +766,23 @@ const removeEmptyValuesAndTrim = (formData: any, schema: JSONSchema): { formData
 
 			return isRequired || Object.keys(object).length > 0 ? object : undefined;
 		} else if (schema && isJSONSchemaArray(schema) && Array.isArray(formData)) {
-			const validItems: Record<number, any> = {};
+			const nonEmptyItems: Record<number, any> = {};
 			formData.forEach((item, idx) => {
 				const value = removeRecursive(item, schema.items, false, `${path}/${idx}`);
 				if (value !== undefined) {
-					validItems[idx] = value;
+					nonEmptyItems[idx] = value;
 				}
 			});
 
-			let missingItems = Math.max((schema.minItems || 0) - Object.keys(validItems).length, 0);
+			let missingItems = Math.max((schema.minItems || 0) - Object.keys(nonEmptyItems).length, 0);
 
 			const array = formData.reduce((arr: any[], item, idx) => {
 				const childPath = `${path}/${idx}`;
-				if (idx in validItems) {
-					arr.push(validItems[idx]);
+				if (idx in nonEmptyItems) {
+					arr.push(nonEmptyItems[idx]);
 				} else if (missingItems > 0) {
 					arr.push(removeRecursive(item, schema.items, true, childPath));
 					missingItems--;
-				} else {
-					removedArrayPaths.push(childPath);
 				}
 				return arr;
 			}, []);

--- a/src/components/LajiForm.tsx
+++ b/src/components/LajiForm.tsx
@@ -773,12 +773,13 @@ const removeEmptyValuesAndTrim = (formData: any, schema: JSONSchema): { formData
 		if (schema && isJSONSchemaObject(schema) && isObject(formData)) {
 			const object = Object.keys(formData).reduce((obj, k) => {
 				const childSchema = schema.properties[k];
-				const value = removeRecursive(formData[k], childSchema, schema.required?.includes(k) || false, `${path}/${k}`);
+				const childPath = `${path}/${k}`;
+				const value = removeRecursive(formData[k], childSchema, schema.required?.includes(k) || false, childPath);
 
 				if (value !== undefined) {
 					obj[k] = value;
 				} else if (childSchema && isJSONSchemaObject(childSchema)) {
-					removedArrayItemsAndObjects.push(`${path}/${k}`);
+					removedArrayItemsAndObjects.push(childPath);
 				}
 
 				return obj;

--- a/src/components/LajiForm.tsx
+++ b/src/components/LajiForm.tsx
@@ -15,7 +15,8 @@ import {
 	ReactUtils,
 	ReactUtilsType,
 	JSONPointerToId,
-	isObject, immutableDelete
+	isObject,
+	immutableDelete
 } from "../utils";
 const equals = require("deep-equal");
 import rjsfValidator from "@rjsf/validator-ajv6";
@@ -745,27 +746,27 @@ export default class LajiForm extends React.Component<LajiFormProps, LajiFormSta
 
 		let schemaErrors = toErrorSchema(errors);
 
-		const removedArrayPaths = this.getFormDataReadyForSubmit(formData, this.props.schema).removedArrayPaths;
-		removedArrayPaths.forEach(path => {
+		const removedPaths = this.getFormDataReadyForSubmit(formData, this.props.schema).removedPaths;
+		removedPaths.forEach(path => {
 			schemaErrors = immutableDelete(schemaErrors, path);
 		});
 
 		return schemaErrors;
 	};
 
-	getFormDataReadyForSubmit = (formData: any, schema: JSONSchema): { formData: any, removedArrayPaths: string[] } => {
+	getFormDataReadyForSubmit = (formData: any, schema: JSONSchema): { formData: any, removedPaths: string[] } => {
 		formData = this.memoizedFormContext.services.ids.removeLajiFormIds(formData);
 		return removeEmptyValuesAndTrim(formData, schema);
 	};
 }
 
 
-const removeEmptyValuesAndTrim = (formData: any, schema: JSONSchema): { formData: any, removedArrayPaths: string[] } => {
-	const removedArrayPaths: string[] = [];
+const removeEmptyValuesAndTrim = (formData: any, schema: JSONSchema): { formData: any, removedPaths: string[] } => {
+	const removedPaths: string[] = [];
 
 	return {
 		formData: removeRecursive(formData, schema, true, ""),
-		removedArrayPaths
+		removedPaths
 	};
 
 	function removeRecursive(formData: any, schema: JSONSchema | undefined, isRequired: boolean, path: string): any {
@@ -778,7 +779,12 @@ const removeEmptyValuesAndTrim = (formData: any, schema: JSONSchema): { formData
 				return obj;
 			}, {} as Record<string, unknown>);
 
-			return isRequired || Object.keys(object).length > 0 ? object : undefined;
+			if (isRequired || Object.keys(object).length > 0) {
+				return object;
+			} else {
+				removedPaths.push(path);
+				return undefined;
+			}
 		} else if (schema && isJSONSchemaArray(schema) && Array.isArray(formData)) {
 			const nonEmptyItems: Record<number, any> = {};
 			formData.forEach((item, idx) => {
@@ -798,7 +804,7 @@ const removeEmptyValuesAndTrim = (formData: any, schema: JSONSchema): { formData
 					arr.push(removeRecursive(item, schema.items, true, childPath));
 					missingItems--;
 				} else {
-					removedArrayPaths.push(childPath);
+					removedPaths.push(childPath);
 				}
 				return arr;
 			}, []);

--- a/src/components/LajiForm.tsx
+++ b/src/components/LajiForm.tsx
@@ -15,7 +15,7 @@ import {
 	ReactUtils,
 	ReactUtilsType,
 	JSONPointerToId,
-	isObject
+	isObject, immutableDelete
 } from "../utils";
 const equals = require("deep-equal");
 import rjsfValidator from "@rjsf/validator-ajv6";
@@ -489,7 +489,7 @@ export default class LajiForm extends React.Component<LajiFormProps, LajiFormSta
 			if (formData !== this.state.formData) {
 				this.validateAndSubmit(warnings, onlySchema);
 			} else if (valid) {
-				formData = this.getFormDataReadyForSubmit(formData, schema);
+				formData = this.getFormDataReadyForSubmit(formData, schema).formData;
 				this.setState({ formData });
 				onSubmit?.({ formData });
 			} else {
@@ -742,18 +742,31 @@ export default class LajiForm extends React.Component<LajiFormProps, LajiFormSta
 			undefined,
 			((e: any) => transformErrors(this.state.formContext.translations, e))
 		).errors;
-		return toErrorSchema(errors);
+
+		let schemaErrors = toErrorSchema(errors);
+
+		const removedArrayPaths = this.getFormDataReadyForSubmit(formData, this.props.schema).removedArrayPaths;
+		removedArrayPaths.forEach(path => {
+			schemaErrors = immutableDelete(schemaErrors, path);
+		});
+
+		return schemaErrors;
 	};
 
-	getFormDataReadyForSubmit = (formData: any, schema: JSONSchema): any => {
+	getFormDataReadyForSubmit = (formData: any, schema: JSONSchema): { formData: any, removedArrayPaths: string[] } => {
 		formData = this.memoizedFormContext.services.ids.removeLajiFormIds(formData);
 		return removeEmptyValuesAndTrim(formData, schema);
 	};
 }
 
 
-const removeEmptyValuesAndTrim = (formData: any, schema: JSONSchema): any => {
-	return removeRecursive(formData, schema, true, "");
+const removeEmptyValuesAndTrim = (formData: any, schema: JSONSchema): { formData: any, removedArrayPaths: string[] } => {
+	const removedArrayPaths: string[] = [];
+
+	return {
+		formData: removeRecursive(formData, schema, true, ""),
+		removedArrayPaths
+	};
 
 	function removeRecursive(formData: any, schema: JSONSchema | undefined, isRequired: boolean, path: string): any {
 		if (schema && isJSONSchemaObject(schema) && isObject(formData)) {
@@ -784,6 +797,8 @@ const removeEmptyValuesAndTrim = (formData: any, schema: JSONSchema): any => {
 				} else if (missingItems > 0) {
 					arr.push(removeRecursive(item, schema.items, true, childPath));
 					missingItems--;
+				} else {
+					removedArrayPaths.push(childPath);
 				}
 				return arr;
 			}, []);

--- a/src/components/LajiForm.tsx
+++ b/src/components/LajiForm.tsx
@@ -15,7 +15,8 @@ import {
 	ReactUtils,
 	ReactUtilsType,
 	JSONPointerToId,
-	isObject
+	isObject,
+	immutableDelete
 } from "../utils";
 const equals = require("deep-equal");
 import rjsfValidator from "@rjsf/validator-ajv6";
@@ -38,7 +39,7 @@ import DOMIdService from "../services/dom-id-service";
 import IdService from "../services/id-service";
 import RootInstanceService from "../services/root-instance-service";
 import SingletonMapService from "../services/singleton-map-service";
-import { FieldProps, HasMaybeChildren, Lang } from "../types";
+import { FieldProps, HasMaybeChildren, isJSONSchemaArray, isJSONSchemaObject, JSONSchema, Lang } from "../types";
 import MultiActiveArrayService from "../services/multi-active-array-service";
 import * as fields from "./fields";
 import * as widgets from "./widgets";
@@ -483,15 +484,13 @@ export default class LajiForm extends React.Component<LajiFormProps, LajiFormSta
 
 	validateAndSubmit = (warnings = true, onlySchema = false) => {
 		const {formData} = this.state;
-		const {onValidationError, onSubmit} = this.props;
+		const {onValidationError, onSubmit, schema} = this.props;
 		this.setState({ externalErrors: undefined });
 		return this.validate(warnings, true, onlySchema).then(valid => {
 			if (formData !== this.state.formData) {
 				this.validateAndSubmit(warnings, onlySchema);
 			} else if (valid) {
-				onSubmit?.({formData: removeUndefinedFromArrays(
-					this.memoizedFormContext.services.ids.removeLajiFormIds(formData)
-				)});
+				onSubmit?.({formData: this.getFormDataReadyForSubmit(formData, schema).formData});
 			} else {
 				onValidationError && onValidationError(this.state.extraErrors!);
 			}
@@ -509,8 +508,11 @@ export default class LajiForm extends React.Component<LajiFormProps, LajiFormSta
 		}
 
 		const block = nonlive || onlySchema;
-		
+
+		const { schema } = this.props;
 		const { formData } = this.state;
+		const removedArrayPaths = this.getFormDataReadyForSubmit(formData, schema).removedArrayPaths;
+
 		const {live: liveErrorValidators, rest: errorValidators} =
 			splitLive(this.props.validators, this.props.schema.properties);
 		const {live: liveWarningValidators, rest: warningValidators} =
@@ -543,10 +545,13 @@ export default class LajiForm extends React.Component<LajiFormProps, LajiFormSta
 					? (this.cachedNonliveValidations || {})
 					: merge(_validations, schemaErrors)
 				);
-				const mergedAll = merge(
+				let mergedAll = merge(
 					this.state.externalErrors || {},
 					mergedInternalErrors as any
 				) as any;
+				removedArrayPaths.forEach(path => {
+					mergedAll = immutableDelete(mergedAll, path);
+				});
 				this.validating = false;
 				resolve(!Object.keys(mergedAll).length);
 				if (!equals((this.state.extraErrors || {}), mergedAll)) {
@@ -736,31 +741,73 @@ export default class LajiForm extends React.Component<LajiFormProps, LajiFormSta
 
 	getSchemaValidationErrors = (formData: any) => {
 		const errors = rjsfValidator.validateFormData(
-			removeUndefinedFromArrays(formData),
+			formData,
 			this.props.schema,
 			undefined,
 			((e: any) => transformErrors(this.state.formContext.translations, e))
 		).errors;
 		return toErrorSchema(errors);
 	};
+
+	getFormDataReadyForSubmit = (formData: any, schema: JSONSchema): { formData: any, removedArrayPaths: string[] } => {
+		formData = this.memoizedFormContext.services.ids.removeLajiFormIds(formData);
+		return removeEmptyValuesAndTrim(formData, schema);
+	};
 }
 
-const removeUndefinedFromArrays = (formData: any) => {
-	if (isObject(formData)) {
-		return Object.keys(formData).reduce((obj, k) => {
-			obj[k] = removeUndefinedFromArrays(formData[k]);
-			return obj;
-		}, {} as Record<string, unknown>);
-	} else if (Array.isArray(formData)) {
-		return formData.reduce((filtered, i) => {
-			if (i === undefined || i === null || i === "") {
-				return filtered;
-			}
-			filtered.push(removeUndefinedFromArrays(i));
-			return filtered;
-		}, []);
+
+const removeEmptyValuesAndTrim = (formData: any, schema: JSONSchema): { formData: any, removedArrayPaths: string[] } => {
+	const removedArrayPaths: string[] = [];
+	
+	return {
+		formData: removeRecursive(formData, schema, true, ""),
+		removedArrayPaths
+	};	
+
+	function removeRecursive(formData: any, schema: JSONSchema | undefined, isRequired: boolean, path: string): any {
+		if (schema && isJSONSchemaObject(schema) && isObject(formData)) {
+			const object = Object.keys(formData).reduce((obj, k) => {
+				const value = removeRecursive(formData[k], schema.properties[k], schema.required?.includes(k) || false, `${path}/${k}`);
+				if (value !== undefined) {
+					obj[k] = value;
+				}
+				return obj;
+			}, {} as Record<string, unknown>);
+
+			return isRequired || Object.keys(object).length > 0 ? object : undefined;
+		} else if (schema && isJSONSchemaArray(schema) && Array.isArray(formData)) {
+			const validItems: Record<number, any> = {};
+			formData.forEach((item, idx) => {
+				const value = removeRecursive(item, schema.items, false, `${path}/${idx}`);
+				if (value !== undefined) {
+					validItems[idx] = value;
+				}
+			});
+
+			let missingItems = Math.max((schema.minItems || 0) - Object.keys(validItems).length, 0);
+
+			const array = formData.reduce((arr: any[], item, idx) => {
+				const childPath = `${path}/${idx}`;
+				if (idx in validItems) {
+					arr.push(validItems[idx]);
+				} else if (missingItems > 0) {
+					arr.push(removeRecursive(item, schema.items, true, childPath));
+					missingItems--;
+				} else {
+					removedArrayPaths.push(childPath);
+				}
+				return arr;
+			}, []);
+
+			return isRequired || array.length > 0 ? array : undefined;
+		} else if (formData === null) {
+			return undefined;
+		} else if (typeof formData === "string") {
+			return formData.trim() || undefined;
+		}
+
+		return formData;
 	}
-	return formData;
 };
 
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -31,6 +31,7 @@ export function isJSONSchemaObject(schema: JSONSchema): schema is JSONSchemaObje
 export type JSONSchemaArray<T = JSONSchema, D = never> = JSONShemaTypeCommon<"array", D[]> & {
 	items: T;
 	uniqueItems?: boolean;
+	minItems?: number;
 	maxItems?: number;
 }
 

--- a/test/submit.spec.ts
+++ b/test/submit.spec.ts
@@ -1,0 +1,166 @@
+import { test, expect } from "@playwright/test";
+import { DemoPageForm, createForm } from "./test-utils";
+
+test.describe("Submit", () => {
+
+	let form: DemoPageForm;
+
+	test.describe("empty values are removed from submitted formData", () => {
+
+		const schema = {
+			type: "object",
+			properties: {
+				string: { type: "string" },
+				nonEmptyString: { type: "string" },
+				emptyObject: {
+					type: "object",
+					properties: {
+						a: { type: "string" }
+					}
+				},
+				nonEmptyObject: {
+					type: "object",
+					properties: {
+						a: { type: "string" }
+					}
+				},
+				emptyArray: {
+					type: "array",
+					items: { type: "string" }
+				},
+				nonEmptyArray: {
+					type: "array",
+					items: { type: "string" }
+				},
+				nested: {
+					type: "object",
+					properties: {
+						emptyString: { type: "string" },
+						emptyObject: {
+							type: "object",
+							properties: {
+								a: { type: "string" }
+							}
+						},
+						emptyArray: {
+							type: "array",
+							items: { type: "string" }
+						},
+						kept: { type: "string" }
+					}
+				}
+			}
+		};
+
+		const formData = {
+			string: "",
+			nonEmptyString: "hello",
+			emptyObject: {},
+			nonEmptyObject: { a: "value" },
+			emptyArray: [],
+			nonEmptyArray: ["item"],
+			nested: {
+				emptyString: "",
+				emptyObject: {},
+				emptyArray: [],
+				kept: "yes"
+			}
+		};
+
+		test.beforeAll(async ({ browser }) => {
+			form = await createForm(await browser.newPage());
+		});
+
+		test.beforeEach(async () => {
+			await form.setState({ schema, formData });
+		});
+
+		test("empty strings, objects and arrays are removed", async () => {
+			await form.submit();
+			const submitted = await form.getSubmittedData();
+
+			expect(submitted).not.toHaveProperty("string");
+			expect(submitted).not.toHaveProperty("emptyObject");
+			expect(submitted).not.toHaveProperty("emptyArray");
+
+			expect(submitted.nonEmptyString).toBe("hello");
+			expect(submitted.nonEmptyObject).toEqual({ a: "value" });
+			expect(submitted.nonEmptyArray).toEqual(["item"]);
+		});
+
+		test("nested empty values are removed", async () => {
+			await form.submit();
+			const submitted = await form.getSubmittedData();
+
+			expect(submitted.nested).not.toHaveProperty("emptyString");
+			expect(submitted.nested).not.toHaveProperty("emptyObject");
+			expect(submitted.nested).not.toHaveProperty("emptyArray");
+			expect(submitted.nested.kept).toBe("yes");
+		});
+
+		test("object with only empty values is itself removed", async () => {
+			const allEmptyFormData = {
+				string: "",
+				emptyObject: { a: "" },
+				nonEmptyString: "hi"
+			};
+			await form.setState({ schema, formData: allEmptyFormData });
+			await form.submit();
+			const submitted = await form.getSubmittedData();
+
+			expect(submitted).not.toHaveProperty("string");
+			expect(submitted).not.toHaveProperty("emptyObject");
+			expect(submitted.nonEmptyString).toBe("hi");
+		});
+
+		test("required empty object property is not removed", async () => {
+			const requiredSchema = {
+				type: "object",
+				required: ["requiredObject"],
+				properties: {
+					requiredObject: {
+						type: "object",
+						properties: {
+							a: { type: "string" }
+						}
+					},
+					nonRequiredObject: {
+						type: "object",
+						properties: {
+							a: { type: "string" }
+						}
+					}
+				}
+			};
+			await form.setState({ schema: requiredSchema, formData: { requiredObject: {}, nonRequiredObject: {} } });
+			await form.submit();
+			const submitted = await form.getSubmittedData();
+
+			expect(submitted).toHaveProperty("requiredObject");
+			expect(submitted).not.toHaveProperty("nonRequiredObject");
+		});
+
+		test("object array with minItems: 1 keeps empty object", async () => {
+			const minItemsSchema = {
+				type: "object",
+				properties: {
+					items: {
+						type: "array",
+						minItems: 1,
+						items: {
+							type: "object",
+							properties: {
+								a: { type: "string" }
+							}
+						}
+					}
+				}
+			};
+			await form.setState({ schema: minItemsSchema, formData: { items: [{ a: "" }] } });
+			await form.submit();
+			const submitted = await form.getSubmittedData();
+
+			expect(submitted.items).toHaveLength(1);
+		});
+	});
+});

--- a/test/validation.spec.ts
+++ b/test/validation.spec.ts
@@ -418,4 +418,84 @@ test.describe("Validations", () => {
 			await expect(form.errors.$$all).toHaveCount(1);
 		});
 	});
+
+	test.describe("Validation bypass for empty array items", () => {
+		const schemaWithArrays = {
+			...schema,
+			properties: {
+				...schema.properties,
+				c: {
+					type: "array",
+					items: {
+						type: "string"
+					}
+				},
+				d: {
+					type: "array",
+					items: {
+						type: "object",
+						properties: {
+							d1: {
+								type: "string"
+							},
+							d2: {
+								type: "string"
+							}
+						},
+						required: ["d1"]
+					}
+				},
+				e: {
+					type: "object",
+					properties: {
+						e1: {
+							type: "string"
+						}
+					},
+					required: ["e1"]
+				}
+			}
+		};
+
+		test("doesn't run schema validations for empty string items", async ({browser}) => {
+			form = await createForm(await browser.newPage());
+			const formDataWithEmptyArray = {...formData, c: ["", undefined]};
+			await form.setState({ schema: schemaWithArrays, formData: formDataWithEmptyArray });
+			await form.submit();
+			await expect(form.$blocker).not.toBeVisible();
+
+			await expect(form.errors.$$all).toHaveCount(0);
+		});
+
+		test("doesn't run schema validations for empty object items", async ({browser}) => {
+			form = await createForm(await browser.newPage());
+			const formDataWithEmptyObjects = {...formData, d: [{}]};
+			await form.setState({ schema: schemaWithArrays, formData: formDataWithEmptyObjects });
+			await form.submit();
+			await expect(form.$blocker).not.toBeVisible();
+
+			await expect(form.errors.$$all).toHaveCount(0);
+		});
+
+		test("doesn't run schema validations for empty objects", async ({browser}) => {
+			form = await createForm(await browser.newPage());
+			const formDataWithEmptyObjects = {...formData, e: {}};
+			await form.setState({ schema: schemaWithArrays, formData: formDataWithEmptyObjects });
+			await form.submit();
+			await expect(form.$blocker).not.toBeVisible();
+
+			await expect(form.errors.$$all).toHaveCount(0);
+		});
+
+		test("runs schema validations for non-empty items", async ({browser}) => {
+			form = await createForm(await browser.newPage());
+			const formDataWithEmptyObjects = {...formData, d: [{}, {d2: "abc"}]};
+			await form.setState({ schema: schemaWithArrays, formData: formDataWithEmptyObjects });
+			await form.submit();
+			await expect(form.$blocker).not.toBeVisible();
+
+			await expect(form.errors.$$all).toHaveCount(1);
+			await expect(form.errors.$$all.nth(0)).toHaveText(/d1/);
+		});
+	});
 });


### PR DESCRIPTION
Removes empty objects (`{}`), arrays (`[]`) and strings (`""`) before submit. Also if an array contains empty objects/strings, filter those out. However, if there are required object/array properties then those are not removed. Also if an array has `minItems` option, items are not removed if there would be less items than `minItems` after that. Schema validations are skipped for empty objects and array items that are going to be removed.