### PR TITLE
Added includeEmpty to SelectWidget ui:options

### DIFF
--- a/forms/MHL.1166.json
+++ b/forms/MHL.1166.json
@@ -2623,6 +2623,7 @@
                   },
                   "observationStatus": {
                     "type": "string",
+                    "default": "MY.observationStatusNotObserved",
                     "oneOf": [
                       {
                         "const": "",
@@ -3902,6 +3903,12 @@
                 "sideEffects": {
                   "/../recordBasis": "MY.recordBasisHumanObservationAudio"
                 }
+              }
+            },
+            "observationStatus": {
+              "ui:widget": "SelectWidget",
+              "ui:options": {
+                "includeEmpty": false
               }
             },
             "unitGathering": {

--- a/src/components/widgets/SelectWidget.tsx
+++ b/src/components/widgets/SelectWidget.tsx
@@ -84,7 +84,7 @@ export function SearchableDrowndown<T extends string | number>(props: SingleSele
 		uiSchema,
 		options,
 		onChange,
-		includeEmpty = true
+		includeEmpty = options.includeEmpty ?? true
 	} = props;
 	const { theme } = useContext(ReactContext);
 	const { FormControl } = theme;


### PR DESCRIPTION
It seems that there's no `includeEmpty` form option, even though other components may pass it as a param. Now it can be also used in ui:options of SelectWidget.