### PR TITLE
Autocomplete bug fixes and error panel style changes

### DIFF
--- a/src/components/LajiForm.tsx
+++ b/src/components/LajiForm.tsx
@@ -221,7 +221,8 @@ export default class LajiForm extends React.Component<LajiFormProps, LajiFormSta
 		if (this.apiClient && "lang" in props && this.props.lang !== props.lang) {
 			this.apiClient.setLang(props.lang as Lang);
 		}
-		this.setState(this.getStateFromProps(props), this.popErrorListIfNeeded);
+		const popErrorList = props.extraErrors !== this.state?.externalErrors;
+		this.setState(this.getStateFromProps(props), popErrorList ? this.popErrorListIfNeeded : undefined);
 	}
 
 	getStateFromProps(props: LajiFormProps) {

--- a/src/components/LajiForm.tsx
+++ b/src/components/LajiForm.tsx
@@ -229,9 +229,7 @@ export default class LajiForm extends React.Component<LajiFormProps, LajiFormSta
 		const state: LajiFormState = {
 			formContext: this.getMemoizedFormContext(props),
 			externalErrors: props.extraErrors,
-			extraErrors: this.state?.extraErrors
-				? merge(this.state.extraErrors, props.extraErrors || {})
-				: props.extraErrors
+			extraErrors: addExternalErrors(this.state?.extraErrors || {}, props.extraErrors || {})
 		};
 		if (((!this.state && props.schema && Object.keys(props.schema).length) || (this.state && !("formData" in this.state))) || ("formData" in props && props.formData !== this.props.formData)) {
 			state.formData = state.formContext.services.ids.addLajiFormIds(getDefaultFormState(props.schema, props.formData, props.schema))[0];
@@ -544,10 +542,7 @@ export default class LajiForm extends React.Component<LajiFormProps, LajiFormSta
 					? (this.cachedNonliveValidations || {})
 					: merge(_validations, schemaErrors)
 				);
-				const mergedAll = merge(
-					this.state.externalErrors || {},
-					mergedInternalErrors as any
-				) as any;
+				const mergedAll = addExternalErrors(mergedInternalErrors as any, this.state.externalErrors || {});
 				this.validating = false;
 				resolve(!Object.keys(mergedAll).length);
 				if (!equals((this.state.extraErrors || {}), mergedAll)) {
@@ -773,4 +768,24 @@ const getShortcuts = (uiSchema: any) => {
 		"ui:shortcuts": shortcuts
 	} = uiSchema || {};
 	return shortcuts;
+};
+
+const addExternalErrors = (internalErrors: ErrorSchema, externalErrors: ErrorSchema): ErrorSchema => {
+	return merge(internalErrors, processExternalErrors(externalErrors));
+};
+
+const processExternalErrors = (errors: ErrorSchema): ErrorSchema => {
+	const result: ErrorSchema = {};
+
+	if (errors.__errors) {
+		result.__errors = errors.__errors.map(error => `[external]${error}`);
+	}
+
+	for (const key in errors) {
+		if (key !== "__errors" && errors[key]) {
+			result[key] = processExternalErrors(errors[key]);
+		}
+	}
+
+	return result;
 };

--- a/src/components/components/ErrorPanel.tsx
+++ b/src/components/components/ErrorPanel.tsx
@@ -54,7 +54,7 @@ export class ErrorPanel extends React.Component<Props, State> {
 							{title}
 							<span className="pull-right">
 								<GlyphButton glyph={this.state.expanded ? "chevron-up" : "chevron-down"} variant="link" >{ translations[this.state.expanded ? "Close" : "Open"] }</GlyphButton>
-								{showToggle && <GlyphButton glyph="new-window" variant="link" onClick={poppedToggle}>{ translations[popped ? "Unpop" : "Pop"] }</GlyphButton>}
+								{showToggle && <GlyphButton glyph={popped ? "pushpin" : "new-window"} variant="link" onClick={poppedToggle}>{ translations[popped ? "Unpop" : "Pop"] }</GlyphButton>}
 							</span>
 						</div>
 					</div>

--- a/src/components/fields/ScientificNameTaxonAutosuggestField.tsx
+++ b/src/components/fields/ScientificNameTaxonAutosuggestField.tsx
@@ -89,6 +89,7 @@ export default class ScientificNameTaxonAutosuggestField extends React.Component
 			isValueSuggested: this.isValueSuggested,
 			getSuggestionFromValue: this.getSuggestionFromValue,
 			getSuggestionValue: this.getSuggestionValue,
+			findExactMatch: this.findExactMatch,
 			renderSuggestion: this.renderSuggestion,
 			valueContext: {taxonRank, author},
 			taxonRankLabel,
@@ -121,6 +122,10 @@ export default class ScientificNameTaxonAutosuggestField extends React.Component
 
 	getSuggestionValue = (suggestion: any): string => {
 		return suggestion.scientificName;
+	};
+
+	findExactMatch = (suggestions: any[], inputValue = "") => {
+		return suggestions.find(suggestion => (suggestion?.scientificName?.toLowerCase() === inputValue.trim().toLowerCase()));
 	};
 
 	onSuggestionSelected = (suggestion: any, mounted: boolean) => {

--- a/src/components/templates/ErrorListTemplate.js
+++ b/src/components/templates/ErrorListTemplate.js
@@ -91,7 +91,7 @@ export default class ErrorListTemplate extends React.Component {
 					poppedToggle={this.poppedToggle}
 					popped={this.state.popped}
 					formContext={this.props.formContext}
-					footer={footer} />
+					footer={warnings.length === 0 ? footer : null} />
 				<ErrorPanel classNames="warning-panel"
 					ref="warningPanel"
 					errors={warnings}

--- a/src/components/templates/ErrorListTemplate.js
+++ b/src/components/templates/ErrorListTemplate.js
@@ -44,36 +44,36 @@ export default class ErrorListTemplate extends React.Component {
 			const _schema = parseJSONPointer(schema, path);
 			const title = _schema.title || defaultTitle;
 
-			let {errors, warnings} = (__errors || []).reduce(({errors, warnings}, _error) => {
-				if (_error.includes("[warning]")) {
-					warnings.push({
-						label: title,
-						error: formatErrorMessage(_error),
-						id: id
-					});
+			let {externalErrors, errors, warnings} = (__errors || []).reduce(({externalErrors, errors, warnings}, _error) => {
+				const error = {
+					label: title,
+					error: formatErrorMessage(_error),
+					id: id
+				};
+				if (_error.includes("[external]")) {
+					externalErrors.push(error);
+				} else if (_error.includes("[warning]")) {
+					warnings.push(error);
 				} else {
-					errors.push({
-						label: title,
-						error: formatErrorMessage(_error),
-						id: id
-					});
+					errors.push(error);
 				}
-				return {errors, warnings};
-			}, {errors: [], warnings: []});
+				return {externalErrors, errors, warnings};
+			}, {externalErrors: [], errors: [], warnings: []});
 			Object.keys(properties).forEach(prop => {
 				let _path = path;
 				if (prop.match(/^\d+$/)) _path = `${_path}/items`;
 				else _path = `${_path}/properties/${prop}`;
 				const _defaultTitle = _schema.type === "array" || uiSchema["ui:multiLanguage"] ? `${title} (${prop})` : prop;
 				const childErrors = walkErrors(_path, `${id}_${prop}`, errorSchema[prop], uiSchema[prop] || {}, _defaultTitle);
+				externalErrors = [...externalErrors, ...childErrors.externalErrors];
 				errors = [...errors, ...childErrors.errors];
 				warnings = [...warnings, ...childErrors.warnings];
 			});
-			return {errors, warnings};
+			return {externalErrors, errors, warnings};
 		}
 
 		const {Glyphicon} = this.context.theme;
-		const {errors, warnings} = walkErrors("", "root", errorSchema, uiSchema, "");
+		const {externalErrors, errors, warnings} = walkErrors("", "root", errorSchema, uiSchema, "");
 		const footer = (
 			errors.length > 0
 				? <Button onClick={this.revalidate}><Glyphicon glyph="refresh"/> {translations.Revalidate}</Button>
@@ -82,12 +82,23 @@ export default class ErrorListTemplate extends React.Component {
 		return (
 			<div className={`laji-form-error-list${this.state.popped ? " laji-form-popped" : ""}${errors.length === 0 ? " laji-form-warning-list" : ""}`}
 				style={this.state.popped ? {top: (this.props.formContext.topOffset || 0) + 5} : null}>
+				<ErrorPanel
+					classNames="error-panel"
+					ref="externalErrorPanel"
+					errors={externalErrors}
+					title={translations.ExternalErrors}
+					clickHandler={clickHandler}
+					showToggle={true}
+					poppedToggle={this.poppedToggle}
+					popped={this.state.popped}
+					formContext={this.props.formContext}
+					footer={null} />
 				<ErrorPanel classNames="error-panel"
 					ref="errorPanel"
 					errors={errors}
 					title={translations.Errors}
 					clickHandler={clickHandler}
-					showToggle={true}
+					showToggle={externalErrors.length === 0}
 					poppedToggle={this.poppedToggle}
 					popped={this.state.popped}
 					formContext={this.props.formContext}
@@ -97,7 +108,7 @@ export default class ErrorListTemplate extends React.Component {
 					errors={warnings}
 					title={translations.Warnings}
 					clickHandler={clickHandler}
-					showToggle={errors.length === 0}
+					showToggle={externalErrors.length === 0 && errors.length === 0}
 					poppedToggle={this.poppedToggle}
 					popped={this.state.popped}
 					formContext={this.props.formContext}

--- a/src/components/widgets/AutosuggestWidget.js
+++ b/src/components/widgets/AutosuggestWidget.js
@@ -837,6 +837,7 @@ export class Autosuggest extends React.Component {
 					onUnsuggestedSelected={this.onUnsuggestedSelected}
 					highlightFirstSuggestion={highlightFirstSuggestion}
 					suggestionsOpenOnFocus={!this.isSuggested()}
+					getSuggestionValue={this.getSuggestionValue}
 					theme={cssClasses}
 					formContext={this.props.formContext}
 					ref={this.setRef}
@@ -1318,6 +1319,12 @@ class ReactAutosuggest extends React.Component {
 		}
 	}
 
+	getDisplayValue = (suggestion) => {
+		return this.props.getSuggestionValue
+			? this.props.getSuggestionValue(suggestion)
+			: suggestion.value;
+	};
+
 	render() {
 		return (
 			<div onFocus={this.onContainerFocus} onBlur={this.onContainerBlur}>
@@ -1371,7 +1378,7 @@ class ReactAutosuggest extends React.Component {
 				touched: true
 			};
 			if (state.focusedIdx !== undefined) {
-				state.inputValue = this.props.suggestions[state.focusedIdx].value;
+				state.inputValue = this.getDisplayValue(this.props.suggestions[state.focusedIdx]);
 			}
 			this.setState(state);
 			break;
@@ -1379,7 +1386,7 @@ class ReactAutosuggest extends React.Component {
 			e.preventDefault();
 			state = {focusedIdx: this.state.focusedIdx > 0 ? this.state.focusedIdx - 1 : undefined, touched: true};
 			if (state.focusedIdx !== undefined) {
-				state.inputValue = this.props.suggestions[state.focusedIdx].value;
+				state.inputValue = this.getDisplayValue(this.props.suggestions[state.focusedIdx]);
 			}
 			this.setState(state);
 			break;

--- a/src/components/widgets/AutosuggestWidget.js
+++ b/src/components/widgets/AutosuggestWidget.js
@@ -543,7 +543,6 @@ export class Autosuggest extends React.Component {
 				this.setState(state);
 			});
 		} else if (valueContextChanged) {
-			this.setState({isLoading: true});
 			if (this.triggerConvertTimeout) {
 				clearTimeout(this.triggerConvertTimeout);
 			}

--- a/src/components/widgets/AutosuggestWidget.js
+++ b/src/components/widgets/AutosuggestWidget.js
@@ -763,6 +763,11 @@ export class Autosuggest extends React.Component {
 		}
 		const parsedInputValue = this.props.parseInputValue ? this.props.parseInputValue(inputValue) : inputValue;
 
+		if (this.state.suggestion && inputValue === this.getSuggestionValue(this.state.suggestion)) {
+			callback && callback();
+			return;
+		}
+
 		const {selectOnlyOne, selectOnlyNonMatchingBeforeUnsuggested = true, informalTaxonGroups, informalTaxonGroupsValue, allowNonsuggestedValue} = this.props;
 
 		const exactMatch = this.findExactMatch(suggestions, parsedInputValue);
@@ -1464,10 +1469,9 @@ class ReactAutosuggest extends React.Component {
 	onSuggestionMouseUp = (e) => {
 		this.suggestionMouseDownFlag = false;
 		const suggestion = this.getSuggestionFromClick(e);
-		this.setState({inputValue: suggestion.value}, () => {
-			this._onInputChange(suggestion.value, "click");
-			this.onBlur(e);
-		});
+		this.onSuggestionSelected(suggestion);
+		this.setState({focused: false, focusedIdx: undefined, touched: false});
+		this.props.inputProps?.onBlur?.(e, true);
 	};
 
 	getSuggestionFromClick = ({target}) => {

--- a/src/translations.json
+++ b/src/translations.json
@@ -66,7 +66,7 @@
 	},
 	"unknownName": {
 		"fi": "Ei tunnettu nimi",
-		"en": "Not known name",
+		"en": "Name not known",
 		"sv": "Okänt namn"
 	},
 	"unknownOrganization": {

--- a/src/translations.json
+++ b/src/translations.json
@@ -354,6 +354,11 @@
 		"en": "below",
 		"sv": "under"
 	},
+	"externalErrors": {
+		"fi": "virheet tallennettaessa",
+		"en": "errors while saving",
+		"sv": "fel när du sparar"
+	},
 	"errors": {
 		"fi": "virheet",
 		"en": "errors",

--- a/test/specimen-form.spec.ts
+++ b/test/specimen-form.spec.ts
@@ -220,6 +220,13 @@ test.describe("specimen form (MHL.1158)", () => {
 					expect(formData.gatherings[0].units[0].identifications[0].taxonRank).toEqual("MX.kingdom");
 					expect(formData.gatherings[0].units[0].identifications[0].author).toEqual("(Lichtenstein, 1823)");
 				});
+
+				test("browsing suggestions with array keys should show the scientific name in the input", async () => {
+					await taxonAutosuggest.$input.fill("susi");
+					await expect(taxonAutosuggest.$suggestionsContainer).toBeVisible();
+					await taxonAutosuggest.$input.press("ArrowDown");
+					await expect(taxonAutosuggest.$input).toHaveValue("Canis lupus");
+				});
 			});
 		});
 

--- a/test/specimen-form.spec.ts
+++ b/test/specimen-form.spec.ts
@@ -6,7 +6,9 @@ import {
 	getFocusedElement,
 	getRemoveUnit,
 	updateValue,
-	DateWidgetPO, ImageArrayFieldPOI, TaxonAutosuggestWidgetPOI
+	DateWidgetPO,
+	ImageArrayFieldPOI,
+	TaxonAutosuggestWidgetPOI
 } from "./test-utils";
 import { MapPageObject } from "@luomus/laji-map/test-export/test-utils";
 
@@ -158,6 +160,11 @@ test.describe("specimen form (MHL.1158)", () => {
 					taxonRankEnum$ = form.$getEnumWidget("gatherings.0.units.0.identifications.0.taxonRank");
 				});
 
+				test.afterEach(async () => {
+					await page.locator("#root_gatherings_0_units_0_identifications_0-delete").click();
+					await $identificationAdd.click();
+				});
+
 				test("selecting a value from suggestions works", async () => {
 					await taxonAutosuggest.$input.fill("susi");
 					await taxonAutosuggest.$suggestions.first().click();
@@ -172,6 +179,8 @@ test.describe("specimen form (MHL.1158)", () => {
 				});
 
 				test("typing a value with no suggestion works", async () => {
+					await taxonAutosuggest.$input.fill("susi");
+					await taxonAutosuggest.$suggestions.first().click();
 					await taxonAutosuggest.$input.fill("susikoira");
 					await taxonAutosuggest.$input.press("Tab");
 
@@ -198,6 +207,8 @@ test.describe("specimen form (MHL.1158)", () => {
 				});
 
 				test("changing a wrong taxon rank shows the warning sign", async () => {
+					await taxonAutosuggest.$input.fill("zootoca vivipara");
+					await taxonAutosuggest.$input.press("Tab");
 					await taxonRankEnum$.openEnums();
 					await taxonRankEnum$.$$enums.nth(3).click();
 

--- a/test/test-utils.ts
+++ b/test/test-utils.ts
@@ -125,18 +125,18 @@ export class Form {
 	createValidatorPO = (type: "error" | "warning") => ({
 		$$all: this.$locator.locator(`.laji-form-error-list:not(.laji-form-failed-jobs-list) .${type}-panel .list-group button`),
 		$panel: this.$locator.locator(`.laji-form-error-list:not(.laji-form-failed-jobs-list) .${type}-panel`)
-	})
+	});
 
-	errors = this.createValidatorPO("error")
-	warnings = this.createValidatorPO("warning")
+	errors = this.createValidatorPO("error");
+	warnings = this.createValidatorPO("warning");
 	failedJobs = {
 		$container: this.$locator.locator(".laji-form-failed-jobs-list"),
 		$$errors: this.$locator.locator(".laji-form-failed-jobs-list .list-group-item")
-	}
+	};
 
 	$runningJobs = this.$locator.locator(".running-jobs");
 
-	$acknowledgeWarnings = this.$locator.locator(".laji-form-warning-list .panel-footer button")
+	$acknowledgeWarnings = this.$locator.locator(".laji-form-warning-list .panel-footer button");
 	$blocker = this.page.locator(".laji-form.blocking-loader");
 	$mapFieldFullscreenMap = this.$locator.locator(".laji-form.fullscreen .laji-form-map");
 
@@ -210,7 +210,7 @@ export class Form {
 			$modalClose: $modal.locator(".modal-header .close"),
 			$addModalCancel: $addModal.locator(".cancel")
 		};
-	}
+	};
 
 	getAutosuggestWidget = (lajiFormLocator: string) => {
 		return {
@@ -219,7 +219,7 @@ export class Form {
 			$suggestions: this.$locate(lajiFormLocator).locator(".rw-list-option"),
 			$loadingSpinner: this.$locate(lajiFormLocator).locator(".react-spinner"),
 		};
-	}
+	};
 
 	getTaxonAutosuggestWidget = (lajiFormLocator: string) => {
 		const autosuggest = this.getAutosuggestWidget(lajiFormLocator);
@@ -229,7 +229,7 @@ export class Form {
 			$suggestedGlyph: this.$locate(lajiFormLocator).locator(".glyphicon-ok"),
 			$nonsuggestedGlyph: this.$locate(lajiFormLocator).locator(".glyphicon-warning-sign"),
 		};
-	}
+	};
 
 	getPersonAutosuggestWidget = (lajiFormLocator: string) => {
 		const autosuggest = this.getAutosuggestWidget(lajiFormLocator);
@@ -237,7 +237,7 @@ export class Form {
 			...autosuggest,
 			$suggestedGlyph: this.$locate(lajiFormLocator).locator(".glyphicon-user")
 		};
-	}
+	};
 
 	getScopeField = (lajiFormLocator: string) => ({
 		$button: this.$locateButton(lajiFormLocator, "additionals"),
@@ -337,10 +337,10 @@ export class DemoPageForm extends Form {
 
 	setState(state: any) {
 		return this.page.evaluate((state) => {
-			// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+
 			// @ts-ignore
 			const onSubmit = function(data) {window.submittedData = data.formData;};
-			// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+			 
 			// @ts-ignore
 			const onChange = function(formData) {window.changedData = formData;};
 
@@ -409,7 +409,7 @@ export class DemoPageForm extends Form {
 				await mdRemove();
 			}
 		};
-	}
+	};
 }
 
 export async function createForm(page: Page, props?: DemoPageProps, beforeInit?: (form: Form) => Promise<void>): Promise<DemoPageForm> {
@@ -457,5 +457,4 @@ export const updateValue = async ($input: Locator, value: string) => {
 export const getRemoveUnit = (page: Page) => async (gatheringIdx: number, unitIdx: number) => {
 	await page.locator(`#root_gatherings_${gatheringIdx}_units_${unitIdx}-delete`).click();
 	return page.locator(`#root_gatherings_${gatheringIdx}_units_${unitIdx}-delete-confirm-yes`).click();
-}
-;
+};

--- a/test/trip-report-autosuggest.spec.ts
+++ b/test/trip-report-autosuggest.spec.ts
@@ -329,5 +329,56 @@ test.describe("Trip report (JX.519) autosuggestions", () => {
 			await $addUnit.click();
 		});
 
+
+		test.describe("multiple exact matches", () => {
+			test("selecting a value from suggestions works", async () => {
+				await taxonAutosuggest.$input.fill("Petunia");
+				await taxonAutosuggest.$suggestions.nth(1).click();
+
+				await expect(taxonAutosuggest.$suggestedGlyph).toBeVisible();
+				await expect(taxonAutosuggest.$input).toHaveValue("Petunia");
+
+				const formData = await form.getChangedData();
+				expect(formData.gatherings[0].units[0].identifications[0].taxon).toEqual("Petunia");
+
+				await removeUnit(0, 0);
+				await $addUnit.click();
+			});
+
+			test("typing a value with suggestion works", async () => {
+				await taxonAutosuggest.$input.fill("Petunia");
+				await expect(taxonAutosuggest.$suggestionsContainer).toBeVisible();
+				await taxonAutosuggest.$input.press("ArrowDown");
+				await taxonAutosuggest.$input.press("ArrowDown");
+				await taxonAutosuggest.$input.press("Tab");
+
+				await expect(taxonAutosuggest.$suggestedGlyph).toBeVisible();
+				await expect(taxonAutosuggest.$input).toHaveValue("Petunia");
+
+				const formData = await form.getChangedData();
+				expect(formData.gatherings[0].units[0].identifications[0].taxon).toEqual("Petunia");
+
+				await removeUnit(0, 0);
+				await $addUnit.click();
+			});
+
+			test("typing a value with suggestion works and enter is pressed", async () => {
+				await taxonAutosuggest.$input.fill("Petunia");
+				await expect(taxonAutosuggest.$suggestionsContainer).toBeVisible();
+				await taxonAutosuggest.$input.press("ArrowDown");
+				await taxonAutosuggest.$input.press("ArrowDown");
+				await taxonAutosuggest.$input.press("Enter");
+				await taxonAutosuggest.$input.press("Tab");
+
+				await expect(taxonAutosuggest.$suggestedGlyph).toBeVisible();
+				await expect(taxonAutosuggest.$input).toHaveValue("Petunia");
+
+				const formData = await form.getChangedData();
+				expect(formData.gatherings[0].units[0].identifications[0].taxon).toEqual("Petunia");
+
+				await removeUnit(0, 0);
+				await $addUnit.click();
+			});
+		});
 	});
 });

--- a/test/validation.spec.ts
+++ b/test/validation.spec.ts
@@ -418,4 +418,28 @@ test.describe("Validations", () => {
 			await expect(form.errors.$$all).toHaveCount(1);
 		});
 	});
+
+	test.describe("External errors", () => {
+		const externalErrorMessage = "external error!";
+		const extraErrors = { a: { __errors: [externalErrorMessage] } };
+
+		test("shows external errors", async () => {
+			await form.setState({ schema, formData });
+			await form.setState({ extraErrors });
+
+			await expect(form.errors.$$all).toHaveCount(1);
+			await expect(form.errors.$$all.nth(0)).toHaveText(new RegExp(externalErrorMessage));
+		});
+
+		test("clears external errors on submit", async () => {
+			await form.setState({ schema, formData });
+			await form.setState({ extraErrors });
+
+			await expect(form.errors.$$all).toHaveCount(1);
+
+			await form.submit();
+
+			await expect(form.errors.$$all).toHaveCount(0);
+		});
+	});
 });


### PR DESCRIPTION
Error panel changes:
- external errors are shown in their own panel with a title "Errors while saving". Validate again button is not shown with external errors because validation won't clear external errors
- pop the error list only when `extraErrors` prop changes, no need to do that when other props like `formData` changes
- show pushpin icon next to the "pin to top" text when error panel is floating
- don't show footer twice if there are both warnings and errors

Autocomplete bugs that are fixed:
- it was not possible to select the correct value when there are multiple exact matches (go to https://laji.fi/project/JX.519/form and write Petunia to the taxon field, select the second option -> it selects the first option "tarhapetunia" instead)
- when browsing taxons with arrow keys in the specimen form (http://localhost:8083/?id=MHL.1158), it showed the matched name when it should always show the scientific name
- specimen form taxon autocomplete showed the loading spinner too often