### PR TITLE
Added sorting for TaxonSetPopulatorField

### DIFF
--- a/src/components/fields/MultiArrayField.js
+++ b/src/components/fields/MultiArrayField.js
@@ -109,6 +109,12 @@ export default class MultiArrayField extends React.Component {
 			}
 		});
 
+		// preserve original formData order within each group
+		const formDataArray = props.formData || [];
+		groupedItems.forEach(group => {
+			group.sort((a, b) => formDataArray.indexOf(a) - formDataArray.indexOf(b));
+		});
+
 		this.groupedItems = groupedItems;
 		const withoutNonGrouped = [...groupedItems];
 		withoutNonGrouped.pop();

--- a/src/components/fields/MultiArrayField.js
+++ b/src/components/fields/MultiArrayField.js
@@ -53,30 +53,24 @@ export default class MultiArrayField extends React.Component {
 			}
 		}
 
-		const itemGroups = Array(groups.length + 1).fill(undefined).map(_ => []);   
-		const addToGroup = (idx, item) => {
-			const id = getUUID(item);
-			itemGroups[idx].push(item);
-			this.groupItemIds[idx][id] = true;
-			this.itemIds[id] = true;
+		const groupedItems = Array(groups.length + 1).fill(undefined).map(_ => []);   
+		const addToGroup = (groupIdx, item) => {
+			groupedItems[groupIdx].push(item);
 			return true;
 		};
 
-		(props.formData || []).forEach(item => {
-			this.groupItemIds.forEach((_, groupIdx) => {
-				if (this.groupItemIds[groupIdx][getUUID(item)]) {
-					addToGroup(groupIdx, item);
-				}
-			});
-		});
-
 		const nonGrouped = [];
-		const groupedItems = (props.formData || []).reduce((itemGroups, item, idx) => {
-			const addedToGroup = groups.some((group, groupIdx) => {
-				if (this.itemIds[getUUID(item)]) {
-					return true;
+		(props.formData || []).forEach((item, idx) => {
+			const id = getUUID(item);
+			// Restore persisted group
+			for (let g = 0; g < this.groupItemIds.length; g++) {
+				if (this.groupItemIds[g][id]) {
+					addToGroup(g, item);
+					return;
 				}
+			}
 
+			const addedToGroup = groups.some((group, groupIdx) => {
 				const {rules = []} = group; 
 				let passes;
 				if (cache) {
@@ -96,8 +90,7 @@ export default class MultiArrayField extends React.Component {
 			if (!addedToGroup) {
 				nonGrouped.push([item, idx]);
 			}
-			return itemGroups;
-		}, itemGroups);
+		});
 
 		nonGrouped.forEach(([item, idx]) => {
 			const context = getContext(`${persistenceKey}_MULTI`);
@@ -107,12 +100,6 @@ export default class MultiArrayField extends React.Component {
 			} else {
 				addToGroup(groupIdx, item);
 			}
-		});
-
-		// preserve original formData order within each group
-		const formDataArray = props.formData || [];
-		groupedItems.forEach(group => {
-			group.sort((a, b) => formDataArray.indexOf(a) - formDataArray.indexOf(b));
 		});
 
 		this.groupedItems = groupedItems;

--- a/src/components/fields/TaxonSetPopulatorField.tsx
+++ b/src/components/fields/TaxonSetPopulatorField.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import * as PropTypes from "prop-types";
 import { FieldProps } from "../../types";
 import VirtualSchemaField from "../VirtualSchemaField";
+import { addLajiFormIds } from "../..//utils";
 
 const propsPropType = PropTypes.shape({
 	from: PropTypes.string.isRequired,
@@ -155,16 +156,17 @@ export default class TaxonSetPopulatorField extends React.Component<FieldProps> 
 
 			const results = await this.fetchTaxaFromSet(this.props, addedTaxonSets);
 
+			const tmpIdTree = this.props.formContext.services.ids.getRelativeTmpIdTree(this.props.idSchema.units.$id);
 			const newUnits = results.map((result: any) => {
 				this.unitTaxonSets[result.id] = result.taxonSets || [];
-				return {
+				return addLajiFormIds({
 					identifications: [{
 						taxon: result.scientificName,
 						taxonID: result.id,
 						taxonVerbatim: result.vernacularName
 					}],
 					informalTaxonGroups: result.informalTaxonGroups || []
-				};
+				}, tmpIdTree, false)[0];
 			});
 
 			const sortedUnits = this.sortByTaxonSet([...currentUnits, ...newUnits], currentTaxonSets);

--- a/src/components/fields/TaxonSetPopulatorField.tsx
+++ b/src/components/fields/TaxonSetPopulatorField.tsx
@@ -128,10 +128,14 @@ export default class TaxonSetPopulatorField extends React.Component<FieldProps> 
 					return !this.unitTaxonSets[unit.identifications[0].taxonID]
 					|| !this.unitTaxonSets[unit.identifications[0].taxonID].includes(deletedTaxonSetId);
 				});
+
+				const sortedUnits = this.sortByTaxonSet(updatedUnits, currentTaxonSets);
+
 				const updatedFormData = {
 					...formData,
-					units: updatedUnits
+					units: sortedUnits
 				};
+
 				this.props.onChange(updatedFormData);
 			});
 			return;
@@ -151,21 +155,6 @@ export default class TaxonSetPopulatorField extends React.Component<FieldProps> 
 
 			const results = await this.fetchTaxaFromSet(this.props, addedTaxonSets);
 
-			// sort results by taxon set (lowest index of result's taxon sets in addedTaxonSets)
-			if (addedTaxonSets.length > 1) {
-				results.sort((a: any, b: any) => {
-					const aIndex = (a.taxonSets || []).reduce((min: number, taxonSet: string) => {
-						const idx = addedTaxonSets.indexOf(taxonSet);
-						return idx !== -1 && idx < min ? idx : min;
-					}, addedTaxonSets.length);
-					const bIndex = (b.taxonSets || []).reduce((min: number, taxonSet: string) => {
-						const idx = addedTaxonSets.indexOf(taxonSet);
-						return idx !== -1 && idx < min ? idx : min;
-					}, addedTaxonSets.length);
-					return aIndex - bIndex;
-				});
-			}
-
 			const newUnits = results.map((result: any) => {
 				this.unitTaxonSets[result.id] = result.taxonSets || [];
 				return {
@@ -178,9 +167,11 @@ export default class TaxonSetPopulatorField extends React.Component<FieldProps> 
 				};
 			});
 
+			const sortedUnits = this.sortByTaxonSet([...currentUnits, ...newUnits], currentTaxonSets);
+
 			const updatedFormData = {
 				...formData,
-				units: [...currentUnits, ...newUnits]
+				units: sortedUnits
 			};
 
 			this.props.onChange(updatedFormData);
@@ -189,6 +180,23 @@ export default class TaxonSetPopulatorField extends React.Component<FieldProps> 
 
 		this.props.onChange(formData);
 	};
+
+	// sort unit by taxon set (lowest index of unit's taxon sets in currentTaxonSets)
+	private sortByTaxonSet(units: any[], taxonSets: string[]): any[] {
+		return units.sort((a: any, b: any) => {
+			const aTaxonSets = this.unitTaxonSets[a.identifications?.[0]?.taxonID] || [];
+			const bTaxonSets = this.unitTaxonSets[b.identifications?.[0]?.taxonID] || [];
+			const aIndex = aTaxonSets.reduce((min: number, taxonSet: string) => {
+				const idx = taxonSets.indexOf(taxonSet);
+				return idx !== -1 && idx < min ? idx : min;
+			}, taxonSets.length);
+			const bIndex = bTaxonSets.reduce((min: number, taxonSet: string) => {
+				const idx = taxonSets.indexOf(taxonSet);
+				return idx !== -1 && idx < min ? idx : min;
+			}, taxonSets.length);
+			return aIndex - bIndex;
+		});
+	}
 
 	private async fetchTaxaFromSet(props: any, taxonSets: any): Promise<any[]> {
 		const apiClient = props.formContext?.apiClient;

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -868,7 +868,7 @@ export function checkArrayRules(rules: any[], props: FieldProps, idx: number, ca
 	const nonArrayRules = (Array.isArray(rules) ? rules : [rules]).filter(rule => !arrayRules.includes(rule));
 	if (nonArrayRules.length) {
 		const nonArrayRulesCheck = checkRules(nonArrayRules, {...props, formData: props.formData[idx]}, cache, prop);
-		const allPass = passes && cache ? (nonArrayRulesCheck as any).passes :  nonArrayRulesCheck;
+		const allPass = passes && cache ? (nonArrayRulesCheck as any).passes : nonArrayRulesCheck;
 		if (cache) {
 			return {passes: allPass, cache};
 		} else {


### PR DESCRIPTION
Without the sort in MultiArrayField, latest units were always added to the bottom of the list, even if I used assignUUID() for them. Lightweight tests pass.